### PR TITLE
docs: cross-link examples with view/edit links

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: acbec10b5a0aa812c2f957053fa5cc67bbc05f9d
+_commit: 34af1eded43e8feca2f8d2a5b8f1eca86b359317
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -400,9 +400,44 @@ Create a new marimo notebook in `examples/<name>.py`:
 
 === "uv run"
 
-    ```bash
-    uv run marimo new examples/<name>.py
-    ```
+2. Develop your example in the marimo editor, following the standardized structure:
+   - **Numbered sections**: Main concepts as `## 1.`, `## 2.`, `## 3.`
+   - **Key Takeaways**: Bullet points summarizing important lessons
+   - **Next Steps**: Links to related notebooks for progression
+   - Isolate utilities and markdown in separate cells
+   - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
+
+   **Pyodide install cell template** (place right after `import marimo as mo`):
+
+   ```python
+   @app.cell(hide_code=True)
+   async def _():
+       import sys
+
+       if "pyodide" in sys.modules:
+           import micropip
+
+           await micropip.install(["scikit-learn"]) # List all packages needed to run the example
+       return
+   ```
+
+   **`hide_code=True` guidance** — mark these cells as hidden:
+
+   | Cell type | Why hidden |
+   |-----------|-----------|
+   | `import marimo as mo` | Boilerplate, not instructive |
+   | Pyodide install | Infrastructure, not tutorial content |
+   | Library imports | Setup, readers focus on usage |
+   | Utilities | Not the lesson |
+   | Markdown cells | Purely structural |
+
+   Leave these cells **visible**:
+
+   | Cell type | Why visible |
+   |-----------|------------|
+   | Model construction / `MyEstimator(...)` | Core teaching content |
+   | `search.fit(...)` calls | Demonstrates usage |
+   | Results display | Shows output interpretation |
 
 #### Required Structure
 

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -1,43 +1,42 @@
 # Examples
 
-Explore real-world applications of Yohou-Optuna through interactive examples. Each notebook uses real datasets from `yohou.datasets` and visualizations from `yohou.plotting`.
+Learn Yohou-Optuna through focused, interactive examples. Each notebook demonstrates one core workflow using real datasets from `yohou.datasets` and visualizations from `yohou.plotting`. Examples are organized from basic usage to advanced patterns and are runnable and editable locally or online.
 
-## What can Yohou-Optuna do?
+## Getting Started
 
-### Quickstart Search
+### Quickstart Search ([View](/examples/optuna_search/) | [Editable](/examples/optuna_search/edit/))
 
-Load the Air Passengers dataset, define search distributions, run `OptunaSearchCV`, and visualize results with `plot_cv_results_scatter` and `plot_forecast`. The best starting point for new users.
+**Your First Hyperparameter Search**
 
-[:material-notebook: optuna_search.py](../examples/optuna_search/)
+Start here to understand the fundamental `OptunaSearchCV` workflow. This example loads the Air Passengers dataset, defines search distributions for Ridge regression parameters, runs a complete hyperparameter search, and visualizes results. You'll learn the three essential steps every search needs: defining parameter distributions, fitting the search, and inspecting results with `plot_cv_results_scatter` and `plot_forecast`.
 
-### Composed Forecaster Tuning
+## Core Workflows
 
-Tune nested parameters in a `PointReductionForecaster` with `LagTransformer` -- use autocorrelation analysis to motivate lag selection, optimize with `ExpandingWindowSplitter`, and diagnose residuals. Uses the Sunspots dataset.
+### Composed Forecaster Tuning ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/))
 
-[:material-notebook: composed_tuning.py](../examples/composed_tuning/)
+**Tuning Nested Parameters in Reduction Forecasters**
 
-### Multi-Metric Search
+Dive into tuning composed estimators by optimizing both a Ridge regressor and its `LagTransformer` feature pipeline. This example uses the Sunspots dataset and autocorrelation analysis to motivate lag selection, then searches over nested parameters with `ExpandingWindowSplitter` cross-validation. You'll see how the double-underscore syntax (`feature_transformer__lag`) reaches into nested components, and how to diagnose results with residual plots.
 
-Evaluate multiple scoring metrics (MAE, RMSE, MSE) in a single search pass. Compare rankings across metrics with `plot_model_comparison_bar` and visualize multivariate data from the ETT-M1 dataset.
+### Multi-Metric Search ([View](/examples/multi_metric_search/) | [Editable](/examples/multi_metric_search/edit/))
 
-[:material-notebook: multi_metric_search.py](../examples/multi_metric_search/)
+**Evaluating Multiple Scoring Metrics Simultaneously**
 
-### Search Visualization
+Evaluate MAE, RMSE, and MSE in a single search pass instead of running separate searches for each metric. This example uses multivariate data from the ETT-M1 dataset and demonstrates how different metrics can rank the same trials differently. You'll compare the best trial selected by each metric using `plot_model_comparison_bar`, and understand when `refit` matters for choosing the final forecaster.
 
-Combine Optuna's built-in optimization plots (history, importances, contour) with yohou's forecast diagnostics (`plot_cv_results_scatter`, `plot_forecast`, `plot_residual_time_series`). Uses Victoria Electricity data.
+## Advanced Topics
 
-[:material-notebook: search_visualization.py](../examples/search_visualization/)
+### Search Visualization ([View](/examples/search_visualization/) | [Editable](/examples/search_visualization/edit/))
 
-### Panel Data Tuning
+**Combining Optuna and Yohou Visualization**
 
-Tune forecasters on grouped time series from the Australian Tourism dataset. Visualize CV splits with `plot_splits`, compare Random vs TPE samplers, and use `MaxTrialsCallback` for early stopping.
+Explore the full diagnostic toolkit by combining Optuna's built-in optimization plots (history, parameter importances, contour) with yohou's forecast diagnostics (`plot_cv_results_scatter`, `plot_forecast`, `plot_residual_time_series`). This example uses Victoria Electricity demand data and shows how the two visualization ecosystems complement each other -- Optuna for understanding the search process, yohou for evaluating forecast quality.
 
-[:material-notebook: panel_tuning.py](../examples/panel_tuning/)
+### Panel Data Tuning ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/))
 
-Each example is available in two formats:
+**Hyperparameter Search on Grouped Time Series**
 
-- **[View](/examples/optuna_search/)** — Static HTML for quick reading
-- **[Editable](/examples/optuna_search/edit/)** — Interactive WASM notebook that runs entirely in your browser (no server needed)
+Apply `OptunaSearchCV` to panel data from the Australian Tourism dataset, where multiple related time series are tuned jointly. This example visualizes cross-validation splits with `plot_splits`, compares Random and TPE sampling strategies side by side, and demonstrates `MaxTrialsCallback` for early stopping. Essential for understanding how yohou-optuna handles real-world datasets with hierarchical structure.
 
 ## Running Examples Locally
 
@@ -56,5 +55,6 @@ just example optuna_search.py
 
 ## Next Steps
 
-- Browse the [API Reference](api-reference.md) for detailed documentation
-- Check the [User Guide](user-guide.md) to understand core concepts
+- **[User Guide](user-guide.md)** — Deep dive into core concepts and architecture
+- **[API Reference](api-reference.md)** — Complete OptunaSearchCV documentation
+- **[Contributing](contributing.md)** — Add your own examples or improve existing ones

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -34,6 +34,11 @@ Tune forecasters on grouped time series from the Australian Tourism dataset. Vis
 
 [:material-notebook: panel_tuning.py](../examples/panel_tuning/)
 
+Each example is available in two formats:
+
+- **[View](/examples/optuna_search/)** — Static HTML for quick reading
+- **[Editable](/examples/optuna_search/edit/)** — Interactive WASM notebook that runs entirely in your browser (no server needed)
+
 ## Running Examples Locally
 
 All examples are [Marimo](https://marimo.io) reactive notebooks stored as `.py` files:

--- a/docs/pages/user-guide.md
+++ b/docs/pages/user-guide.md
@@ -88,6 +88,9 @@ search.observe(y_new, X_new)
 y_pred_updated = search.predict(forecasting_horizon=12)
 ```
 
+!!! example "Interactive Example"
+    See [**Quickstart Search**](/examples/optuna_search/) ([View](/examples/optuna_search/) | [Editable](/examples/optuna_search/edit/)) for a complete walkthrough of the search lifecycle using the Air Passengers dataset.
+
 ### Wrapper Classes
 
 Optuna's `BaseSampler`, `BaseStorage`, and callback objects are not compatible with sklearn's `clone()` (used internally during cross-validation). Yohou-Optuna provides wrapper classes that serialize the class name and constructor arguments, enabling safe cloning:
@@ -129,6 +132,9 @@ param_distributions = {
 }
 ```
 
+!!! example "Interactive Example"
+    See [**Composed Forecaster Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/)) for a demonstration of tuning nested parameters with `IntDistribution` and `FloatDistribution`.
+
 ## Key Features
 
 ### 1. Sampler Selection
@@ -147,6 +153,9 @@ search = OptunaSearchCV(
 )
 ```
 
+!!! example "Interactive Example"
+    See [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/)) for a side-by-side comparison of Random vs TPE samplers on the Australian Tourism dataset.
+
 ### 2. Callbacks
 
 Use callbacks for early stopping, logging, or custom logic:
@@ -163,6 +172,9 @@ search = OptunaSearchCV(
     ],
 )
 ```
+
+!!! example "Interactive Example"
+    See [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/)) for a demonstration of `MaxTrialsCallback` for early stopping.
 
 ### 3. Study Persistence
 
@@ -203,6 +215,9 @@ search = OptunaSearchCV(
 
 When `scoring` is a list or dict, `cv_results_` contains columns for each metric. Set `refit` to the metric name used for selecting the best forecaster.
 
+!!! example "Interactive Example"
+    See [**Multi-Metric Search**](/examples/multi_metric_search/) ([View](/examples/multi_metric_search/) | [Editable](/examples/multi_metric_search/edit/)) for evaluating MAE, RMSE, and MSE simultaneously on the ETT-M1 dataset.
+
 ### 5. Training Scores
 
 Optionally compute scores on the training folds:
@@ -237,6 +252,9 @@ param_distributions = {
     "decomposer__period": IntDistribution(4, 24),
 }
 ```
+
+!!! example "Interactive Example"
+    See [**Composed Forecaster Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/)) for tuning a `PointReductionForecaster` with a `LagTransformer` feature pipeline.
 
 ## Configuration
 
@@ -323,10 +341,18 @@ optuna.visualization.plot_optimization_history(search.study_)
 optuna.visualization.plot_param_importances(search.study_)
 ```
 
+!!! example "Interactive Example"
+    See [**Search Visualization**](/examples/search_visualization/) ([View](/examples/search_visualization/) | [Editable](/examples/search_visualization/edit/)) for a complete comparison of Optuna's optimization plots alongside yohou's forecast diagnostics.
+
 ## Next Steps
 
 Now that you understand the core concepts and features:
 
 - Follow the [Getting Started](getting-started.md) guide to start using Yohou-Optuna
-- Explore the [Examples](examples.md) for real-world use cases
+- Explore the [Examples](examples.md) for interactive notebooks:
+    - [**Quickstart Search**](/examples/optuna_search/) ([View](/examples/optuna_search/) | [Editable](/examples/optuna_search/edit/)) — Your first hyperparameter search
+    - [**Composed Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/)) — Nested parameter tuning
+    - [**Multi-Metric Search**](/examples/multi_metric_search/) ([View](/examples/multi_metric_search/) | [Editable](/examples/multi_metric_search/edit/)) — Multiple scoring metrics
+    - [**Search Visualization**](/examples/search_visualization/) ([View](/examples/search_visualization/) | [Editable](/examples/search_visualization/edit/)) — Optuna + yohou plots
+    - [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/)) — Grouped time series
 - Check the [API Reference](api-reference.md) for detailed API documentation


### PR DESCRIPTION
## Description

Cross-link examples pages with interactive View/Edit links in both the user guide and examples page. Restructure examples page with categorized sections and richer descriptions.

## Type of Change

- [x] Documentation update

## Motivation and Context

The examples and user guide pages lacked direct links to the interactive (View/Editable) Marimo notebooks, making it harder for users to jump into hands-on learning. This adds consistent cross-linking throughout both pages.

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Documentation-only change — no code or test changes.