### PR TITLE
chore: apply copier template v0.14.0 changes

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: f4f1d235602eafd3c611bd4fa8c1efe427acde5c
+_commit: d439e067d6a4a123dc84d1c27642e2cd03356d67
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/docs/pages/contributing.md
+++ b/docs/pages/contributing.md
@@ -205,7 +205,6 @@ Run tests across multiple Python versions:
     ```bash
     uvx nox -s test
     ```
-
 Run example notebook tests:
 
 === "just"
@@ -243,12 +242,10 @@ Mark your tests appropriately to help maintain fast feedback during development:
   - Test multiple components working together
   - Require complex setup or teardown
   - Exercise end-to-end workflows
-
 - `@pytest.mark.example` is used in `tests/test_examples.py` to:
   - Validate example notebooks execute without errors
   - Run notebooks in the `examples/` directory
   - Test interactive documentation and tutorials
-
 
 Example:
 
@@ -405,28 +402,13 @@ Create a new marimo notebook in `examples/<name>.py`:
    - **Key Takeaways**: Bullet points summarizing important lessons
    - **Next Steps**: Links to related notebooks for progression
    - Isolate utilities and markdown in separate cells
-   - Use `hide_code=True` for infrastructure cells: `import marimo`, pyodide install, library imports, utilities, and markdown cells
-
-   **Pyodide install cell template** (place right after `import marimo as mo`):
-
-   ```python
-   @app.cell(hide_code=True)
-   async def _():
-       import sys
-
-       if "pyodide" in sys.modules:
-           import micropip
-
-           await micropip.install(["scikit-learn"]) # List all packages needed to run the example
-       return
-   ```
+   - Use `hide_code=True` for infrastructure cells: `import marimo`, library imports, utilities, and markdown cells
 
    **`hide_code=True` guidance:** mark these cells as hidden:
 
    | Cell type | Why hidden |
    |-----------|-----------|
    | `import marimo as mo` | Boilerplate, not instructive |
-   | Pyodide install | Infrastructure, not tutorial content |
    | Library imports | Setup, readers focus on usage |
    | Utilities | Not the lesson |
    | Markdown cells | Purely structural |
@@ -468,10 +450,31 @@ Basic familiarity with sklearn's fit/predict API and time series concepts (trend
 
 #### Marimo Cell Conventions
 
+- Add [PEP 723](https://peps.python.org/pep-0723/) inline script metadata at the top of each notebook listing its dependencies
 - Use `hide_code=True` on all markdown cells, import cells, and utility/helper cells
 - Use `r"""..."""` (raw triple-quoted strings) for markdown cell content
-- The second cell (after `import marimo as mo`) must be the Pyodide/micropip guard for browser compatibility
-- Group all imports into a single hidden cell after the Pyodide guard
+- Group all imports into a single hidden cell
+
+**PEP 723 header template** (place at the very top of the file, before `import marimo`):
+
+```python
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "my-dependency",
+# ]
+# ///
+```
+
+**What to include in `dependencies`:**
+
+- Only list packages the notebook **directly imports** (e.g., `numpy`, `plotly`)
+- Include `yohou_optuna` when the notebook imports from the project itself
+- Do **not** include `marimo` — it is the runner, not a dependency of the script
+- Do **not** include transitive dependencies (packages already pulled in by a listed dependency)
+- Do **not** add `[tool.uv.sources]` — local development uses workspace resolution automatically; published notebooks should resolve from PyPI
+
+When in doubt, run `uv run --script examples/<name>.py` in a clean environment. If it fails with an `ImportError`, add the missing package.
 
 #### Content Guidelines
 
@@ -509,7 +512,6 @@ Add a link to your example in `docs/pages/examples.md`:
 ```
 
 The mkdocs hooks automatically export notebooks to HTML during docs build. All notebooks in `examples/` are automatically discovered and tested by `test_examples.py` using pytest's parametrization feature, which runs them in parallel for fast validation.
-
 ## Submitting Changes
 
 1. Push your changes to your fork:

--- a/docs/pages/examples.md
+++ b/docs/pages/examples.md
@@ -4,7 +4,7 @@ Learn Yohou-Optuna through focused, interactive examples. Each notebook demonstr
 
 ## Getting Started
 
-### Quickstart Search ([View](/examples/optuna_search/) | [Editable](/examples/optuna_search/edit/))
+### Quickstart Search ([View](/examples/optuna_search/) | [Open in marimo](/examples/optuna_search/edit/))
 
 **Your First Hyperparameter Search**
 
@@ -12,13 +12,13 @@ Start here to understand the fundamental `OptunaSearchCV` workflow. This example
 
 ## Core Workflows
 
-### Composed Forecaster Tuning ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/))
+### Composed Forecaster Tuning ([View](/examples/composed_tuning/) | [Open in marimo](/examples/composed_tuning/edit/))
 
 **Tuning Nested Parameters in Reduction Forecasters**
 
 Dive into tuning composed estimators by optimizing both a Ridge regressor and its `LagTransformer` feature pipeline. This example uses the Sunspots dataset and autocorrelation analysis to motivate lag selection, then searches over nested parameters with `ExpandingWindowSplitter` cross-validation. You'll see how the double-underscore syntax (`feature_transformer__lag`) reaches into nested components, and how to diagnose results with residual plots.
 
-### Multi-Metric Search ([View](/examples/multi_metric_search/) | [Editable](/examples/multi_metric_search/edit/))
+### Multi-Metric Search ([View](/examples/multi_metric_search/) | [Open in marimo](/examples/multi_metric_search/edit/))
 
 **Evaluating Multiple Scoring Metrics Simultaneously**
 
@@ -26,13 +26,13 @@ Evaluate MAE, RMSE, and MSE in a single search pass instead of running separate 
 
 ## Advanced Topics
 
-### Search Visualization ([View](/examples/search_visualization/) | [Editable](/examples/search_visualization/edit/))
+### Search Visualization ([View](/examples/search_visualization/) | [Open in marimo](/examples/search_visualization/edit/))
 
 **Combining Optuna and Yohou Visualization**
 
 Explore the full diagnostic toolkit by combining Optuna's built-in optimization plots (history, parameter importances, contour) with yohou's forecast diagnostics (`plot_cv_results_scatter`, `plot_forecast`, `plot_residual_time_series`). This example uses Victoria Electricity demand data and shows how the two visualization ecosystems complement each other -- Optuna for understanding the search process, yohou for evaluating forecast quality.
 
-### Panel Data Tuning ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/))
+### Panel Data Tuning ([View](/examples/panel_tuning/) | [Open in marimo](/examples/panel_tuning/edit/))
 
 **Hyperparameter Search on Grouped Time Series**
 

--- a/docs/pages/user-guide.md
+++ b/docs/pages/user-guide.md
@@ -89,7 +89,7 @@ y_pred_updated = search.predict(forecasting_horizon=12)
 ```
 
 !!! example "Interactive Example"
-    See [**Quickstart Search**](/examples/optuna_search/) ([View](/examples/optuna_search/) | [Editable](/examples/optuna_search/edit/)) for a complete walkthrough of the search lifecycle using the Air Passengers dataset.
+    See [**Quickstart Search**](/examples/optuna_search/) ([View](/examples/optuna_search/) | [Open in marimo](/examples/optuna_search/edit/)) for a complete walkthrough of the search lifecycle using the Air Passengers dataset.
 
 ### Wrapper Classes
 
@@ -133,7 +133,7 @@ param_distributions = {
 ```
 
 !!! example "Interactive Example"
-    See [**Composed Forecaster Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/)) for a demonstration of tuning nested parameters with `IntDistribution` and `FloatDistribution`.
+    See [**Composed Forecaster Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Open in marimo](/examples/composed_tuning/edit/)) for a demonstration of tuning nested parameters with `IntDistribution` and `FloatDistribution`.
 
 ## Key Features
 
@@ -154,7 +154,7 @@ search = OptunaSearchCV(
 ```
 
 !!! example "Interactive Example"
-    See [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/)) for a side-by-side comparison of Random vs TPE samplers on the Australian Tourism dataset.
+    See [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Open in marimo](/examples/panel_tuning/edit/)) for a side-by-side comparison of Random vs TPE samplers on the Australian Tourism dataset.
 
 ### 2. Callbacks
 
@@ -174,7 +174,7 @@ search = OptunaSearchCV(
 ```
 
 !!! example "Interactive Example"
-    See [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/)) for a demonstration of `MaxTrialsCallback` for early stopping.
+    See [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Open in marimo](/examples/panel_tuning/edit/)) for a demonstration of `MaxTrialsCallback` for early stopping.
 
 ### 3. Study Persistence
 
@@ -216,7 +216,7 @@ search = OptunaSearchCV(
 When `scoring` is a list or dict, `cv_results_` contains columns for each metric. Set `refit` to the metric name used for selecting the best forecaster.
 
 !!! example "Interactive Example"
-    See [**Multi-Metric Search**](/examples/multi_metric_search/) ([View](/examples/multi_metric_search/) | [Editable](/examples/multi_metric_search/edit/)) for evaluating MAE, RMSE, and MSE simultaneously on the ETT-M1 dataset.
+    See [**Multi-Metric Search**](/examples/multi_metric_search/) ([View](/examples/multi_metric_search/) | [Open in marimo](/examples/multi_metric_search/edit/)) for evaluating MAE, RMSE, and MSE simultaneously on the ETT-M1 dataset.
 
 ### 5. Training Scores
 
@@ -254,7 +254,7 @@ param_distributions = {
 ```
 
 !!! example "Interactive Example"
-    See [**Composed Forecaster Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/)) for tuning a `PointReductionForecaster` with a `LagTransformer` feature pipeline.
+    See [**Composed Forecaster Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Open in marimo](/examples/composed_tuning/edit/)) for tuning a `PointReductionForecaster` with a `LagTransformer` feature pipeline.
 
 ## Configuration
 
@@ -342,7 +342,7 @@ optuna.visualization.plot_param_importances(search.study_)
 ```
 
 !!! example "Interactive Example"
-    See [**Search Visualization**](/examples/search_visualization/) ([View](/examples/search_visualization/) | [Editable](/examples/search_visualization/edit/)) for a complete comparison of Optuna's optimization plots alongside yohou's forecast diagnostics.
+    See [**Search Visualization**](/examples/search_visualization/) ([View](/examples/search_visualization/) | [Open in marimo](/examples/search_visualization/edit/)) for a complete comparison of Optuna's optimization plots alongside yohou's forecast diagnostics.
 
 ## Next Steps
 
@@ -350,9 +350,9 @@ Now that you understand the core concepts and features:
 
 - Follow the [Getting Started](getting-started.md) guide to start using Yohou-Optuna
 - Explore the [Examples](examples.md) for interactive notebooks:
-    - [**Quickstart Search**](/examples/optuna_search/) ([View](/examples/optuna_search/) | [Editable](/examples/optuna_search/edit/)): Your first hyperparameter search
-    - [**Composed Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Editable](/examples/composed_tuning/edit/)): Nested parameter tuning
-    - [**Multi-Metric Search**](/examples/multi_metric_search/) ([View](/examples/multi_metric_search/) | [Editable](/examples/multi_metric_search/edit/)): Multiple scoring metrics
-    - [**Search Visualization**](/examples/search_visualization/) ([View](/examples/search_visualization/) | [Editable](/examples/search_visualization/edit/)): Optuna + yohou plots
-    - [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Editable](/examples/panel_tuning/edit/)): Grouped time series
+    - [**Quickstart Search**](/examples/optuna_search/) ([View](/examples/optuna_search/) | [Open in marimo](/examples/optuna_search/edit/)): Your first hyperparameter search
+    - [**Composed Tuning**](/examples/composed_tuning/) ([View](/examples/composed_tuning/) | [Open in marimo](/examples/composed_tuning/edit/)): Nested parameter tuning
+    - [**Multi-Metric Search**](/examples/multi_metric_search/) ([View](/examples/multi_metric_search/) | [Open in marimo](/examples/multi_metric_search/edit/)): Multiple scoring metrics
+    - [**Search Visualization**](/examples/search_visualization/) ([View](/examples/search_visualization/) | [Open in marimo](/examples/search_visualization/edit/)): Optuna + yohou plots
+    - [**Panel Data Tuning**](/examples/panel_tuning/) ([View](/examples/panel_tuning/) | [Open in marimo](/examples/panel_tuning/edit/)): Grouped time series
 - Check the [API Reference](api-reference.md) for detailed API documentation

--- a/examples/composed_tuning.py
+++ b/examples/composed_tuning.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "polars",
+#     "scikit-learn",
+#     "yohou",
+#     "yohou-optuna",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.19.11"
@@ -29,17 +40,6 @@ def _(mo):
         Familiarity with the basics of `OptunaSearchCV` (see optuna_search.py).
         """
     )
-    return
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
     return
 
 

--- a/examples/multi_metric_search.py
+++ b/examples/multi_metric_search.py
@@ -1,3 +1,15 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "numpy",
+#     "optuna",
+#     "polars",
+#     "scikit-learn",
+#     "yohou",
+#     "yohou-optuna",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.19.11"
@@ -29,17 +41,6 @@ def _(mo):
         Familiarity with the basics of `OptunaSearchCV` (see optuna_search.py).
         """
     )
-    return
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
     return
 
 

--- a/examples/optuna_search.py
+++ b/examples/optuna_search.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "polars",
+#     "scikit-learn",
+#     "yohou",
+#     "yohou-optuna",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.19.11"
@@ -30,17 +41,6 @@ def _(mo):
         Basic familiarity with scikit-learn's fit/predict API and time series forecasting concepts.
         """
     )
-    return
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
     return
 
 

--- a/examples/panel_tuning.py
+++ b/examples/panel_tuning.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "polars",
+#     "scikit-learn",
+#     "yohou",
+#     "yohou-optuna",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.19.11"
@@ -31,17 +42,6 @@ def _(mo):
         panel data concepts (multiple related time series sharing the same time index).
         """
     )
-    return
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
     return
 
 

--- a/examples/search_visualization.py
+++ b/examples/search_visualization.py
@@ -1,3 +1,14 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     "optuna",
+#     "polars",
+#     "scikit-learn",
+#     "yohou",
+#     "yohou-optuna",
+# ]
+# ///
+
 import marimo
 
 __generated_with = "0.19.11"
@@ -29,17 +40,6 @@ def _(mo):
         Familiarity with the basics of `OptunaSearchCV` (see optuna_search.py).
         """
     )
-    return
-
-
-@app.cell(hide_code=True)
-async def _():
-    import sys
-
-    if "pyodide" in sys.modules:
-        import micropip
-
-        await micropip.install(["scikit-learn", "optuna", "sklearn-optuna"])
     return
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,9 +103,11 @@ def test_fast(session: nox.Session) -> None:
     )
 
     # Run fast tests only with parallel execution
+    # --no-cov disables coverage (from addopts) so it cannot fail this step
     session.run(
         "pytest",
         "tests",
+        "--no-cov",
         "-m",
         "not slow and not integration and not example",
         "-n",
@@ -240,6 +242,8 @@ def build_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 
@@ -257,6 +261,8 @@ def serve_docs(session: nox.Session) -> None:
         "--no-default-groups",
         "--group",
         "docs",
+        "--group",
+        "examples",
         env={"UV_PROJECT_ENVIRONMENT": session.virtualenv.location},
     )
 


### PR DESCRIPTION
## Description

Apply copier template v0.14.0 changes that failed to merge during `copier update` due to heavy customization in downstream files.

## Type of Change

- [x] Refactoring (no functional changes)

## Motivation and Context

The `copier update` to v0.14.0 only applied changes to `.copier-answers.yml` and `noxfile.py`. The remaining files (`docs/hooks.py`, `docs/pages/contributing.md`, example notebooks, doc pages) were skipped because the 3-way merge couldn't reconcile the template diff with the project-specific customizations. This PR manually applies the missing changes by rendering the v0.14.0 templates with the project's copier variables.

Key changes from template v0.14.0 ([#111](https://github.com/stateful-y/python-package-copier/pull/111)):

- Remove WASM export from `docs/hooks.py`; export HTML-only with `--no-sandbox`
- Add `marimo.app` playground URL resolution for `[Open in marimo]` links
- Use `READTHEDOCS_GIT_COMMIT_HASH` for correct PR preview links on RTD
- Switch notebook discovery from `glob` to recursive `rglob`
- Fail docs build on notebook cell execution errors
- Add PEP 723 inline script metadata to example notebooks
- Remove pyodide/micropip cells from example notebooks
- Update contributing guide with PEP 723 dependency conventions

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just format` to format my code
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

`docs/hooks.py` and `docs/pages/contributing.md` are now exact Jinja-rendered output of the v0.14.0 template, so future `copier update` runs will merge cleanly.