### PR TITLE
feat: add interval forecaster support to OptunaSearchCV

### DIFF
--- a/examples/composed_tuning.py
+++ b/examples/composed_tuning.py
@@ -56,14 +56,14 @@ def _():
     from optuna.distributions import FloatDistribution, IntDistribution
     from sklearn.linear_model import Ridge
 
-    from yohou.datasets import load_sunspots
+    from yohou.datasets import fetch_sunspot
     from yohou.metrics import MeanAbsoluteError
     from yohou.model_selection import ExpandingWindowSplitter
     from yohou.plotting import (
         plot_autocorrelation,
         plot_cv_results_scatter,
         plot_forecast,
-        plot_residual_time_series,
+        plot_residuals,
         plot_time_series,
     )
     from yohou.point import PointReductionForecaster
@@ -83,13 +83,13 @@ def _():
         PointReductionForecaster,
         Ridge,
         Sampler,
-        load_sunspots,
+        fetch_sunspot,
         optuna,
         pl,
         plot_autocorrelation,
         plot_cv_results_scatter,
         plot_forecast,
-        plot_residual_time_series,
+        plot_residuals,
         plot_time_series,
     )
 
@@ -110,8 +110,8 @@ def _(mo):
 
 
 @app.cell
-def _(load_sunspots, plot_time_series):
-    y_full = load_sunspots()
+def _(fetch_sunspot, plot_time_series):
+    y_full = fetch_sunspot().frame
     y = y_full.tail(500)
     plot_time_series(y, title="Sunspot Activity (Last 500 Months)")
     return y, y_full
@@ -300,8 +300,8 @@ def _(plot_forecast, y_pred, y_test, y_train):
 
 
 @app.cell
-def _(plot_residual_time_series, y_pred, y_test):
-    plot_residual_time_series(
+def _(plot_residuals, y_pred, y_test):
+    plot_residuals(
         y_pred,
         y_test,
         title="Forecast Residuals",
@@ -319,7 +319,7 @@ def _(mo):
         - **`LagTransformer`** creates lag-based features automatically, turning time series forecasting into tabular regression
         - **Autocorrelation analysis** helps motivate the range of lags to search over
         - **`ExpandingWindowSplitter`** provides time-respecting cross-validation that avoids data leakage
-        - **Residual diagnostics** with `plot_residual_time_series` reveal systematic prediction errors
+        - **Residual diagnostics** with `plot_residuals` reveal systematic prediction errors
 
         ## Next Steps
 

--- a/examples/multi_metric_search.py
+++ b/examples/multi_metric_search.py
@@ -58,7 +58,7 @@ def _():
     from optuna.distributions import CategoricalDistribution, FloatDistribution
     from sklearn.linear_model import Ridge
 
-    from yohou.datasets import load_ett_m1
+    from yohou.datasets import fetch_electricity_demand
     from yohou.metrics import MeanAbsoluteError, MeanSquaredError, RootMeanSquaredError
     from yohou.model_selection import ExpandingWindowSplitter
     from yohou.plotting import (
@@ -83,7 +83,7 @@ def _():
         Ridge,
         RootMeanSquaredError,
         Sampler,
-        load_ett_m1,
+        fetch_electricity_demand,
         np,
         optuna,
         pl,
@@ -100,26 +100,30 @@ def _(mo):
         r"""
         ## 1. Load and Explore Multivariate Data
 
-        The ETT-M1 (Electricity Transformer Temperature) dataset contains 15-minute
-        measurements of oil temperature and six power load features. We use a subset
-        and select a few columns to keep the search fast while still demonstrating
-        multivariate forecasting.
+        The Electricity Demand dataset contains 30-minute measurements of
+        electricity demand across Australian states. We select three state columns
+        and rename them for multivariate forecasting, then use a subset to keep
+        the search fast.
         """
     )
     return
 
 
 @app.cell
-def _(load_ett_m1, pl):
-    y_full = load_ett_m1()
-    y_all = y_full.select(["time", "OT", "HUFL", "HULL"]).head(1000)
+def _(fetch_electricity_demand, pl):
+    y_full = fetch_electricity_demand().frame
+    y_all = (
+        y_full.select(["time", "nsw__demand", "vic__demand", "qun__demand"])
+        .rename({"nsw__demand": "nsw_demand", "vic__demand": "vic_demand", "qun__demand": "qun_demand"})
+        .head(1000)
+    )
     y_all.head()
     return y_all, y_full
 
 
 @app.cell
 def _(plot_time_series, y_all):
-    plot_time_series(y_all, title="Electricity Transformer: OT, HUFL, HULL")
+    plot_time_series(y_all, title="Electricity Demand: NSW, VIC, QUN")
     return
 
 

--- a/examples/optuna_search.py
+++ b/examples/optuna_search.py
@@ -57,7 +57,7 @@ def _():
     from optuna.distributions import CategoricalDistribution, FloatDistribution
     from sklearn.linear_model import Ridge
 
-    from yohou.datasets import load_air_passengers
+    from yohou.datasets import fetch_sunspot
     from yohou.metrics import MeanAbsoluteError
     from yohou.plotting import plot_cv_results_scatter, plot_forecast, plot_time_series
     from yohou.point import PointReductionForecaster
@@ -74,7 +74,7 @@ def _():
         PointReductionForecaster,
         Ridge,
         Sampler,
-        load_air_passengers,
+        fetch_sunspot,
         optuna,
         pl,
         plot_cv_results_scatter,
@@ -89,19 +89,19 @@ def _(mo):
         r"""
         ## 1. Load and Explore the Data
 
-        We use the classic Air Passengers dataset: 144 monthly observations of
-        international airline passenger counts from 1949 to 1960. This univariate
-        series exhibits both trend and seasonality, making it a good benchmark for
-        forecasting.
+        We use the Sunspot dataset: monthly observations of sunspot activity.
+        This univariate series exhibits strong cyclical patterns (roughly 11-year
+        solar cycles), making it a good benchmark for forecasting. We take the
+        last 144 observations to keep the search fast.
         """
     )
     return
 
 
 @app.cell
-def _(load_air_passengers, plot_time_series):
-    y = load_air_passengers()
-    plot_time_series(y, title="Air Passengers (1949-1960)")
+def _(fetch_sunspot, plot_time_series):
+    y = fetch_sunspot().frame.tail(144)
+    plot_time_series(y, title="Sunspot Activity (Last 144 Months)")
     return (y,)
 
 

--- a/examples/panel_tuning.py
+++ b/examples/panel_tuning.py
@@ -58,7 +58,7 @@ def _():
     from optuna.distributions import CategoricalDistribution, FloatDistribution
     from sklearn.linear_model import Ridge
 
-    from yohou.datasets import load_australian_tourism
+    from yohou.datasets import fetch_tourism_quarterly
     from yohou.metrics import MeanAbsoluteError
     from yohou.model_selection import ExpandingWindowSplitter
     from yohou.plotting import plot_forecast, plot_splits, plot_time_series
@@ -77,7 +77,7 @@ def _():
         PointReductionForecaster,
         Ridge,
         Sampler,
-        load_australian_tourism,
+        fetch_tourism_quarterly,
         optuna,
         pl,
         plot_forecast,
@@ -92,18 +92,23 @@ def _(mo):
         r"""
         ## 1. Load and Explore Panel Data
 
-        The Australian Tourism dataset contains quarterly trip counts for 8 Australian
-        states/territories. Each column follows the `group__member` naming convention
-        (e.g., `victoria__trips`), which yohou recognizes as panel data.
+        The Tourism Quarterly dataset contains quarterly tourist visit counts across
+        427 regions. Each column follows the `group__member` naming convention
+        (e.g., `T1__tourists`), which yohou recognizes as panel data. We select
+        8 regions to keep the search manageable.
         """
     )
     return
 
 
 @app.cell
-def _(load_australian_tourism, plot_time_series):
-    y = load_australian_tourism()
-    plot_time_series(y, title="Australian Tourism: Quarterly Trips by State")
+def _(fetch_tourism_quarterly, plot_time_series):
+    y = (
+        fetch_tourism_quarterly()
+        .frame.select(["time"] + [f"T{i}__tourists" for i in range(3, 11)])
+        .drop_nulls()
+    )
+    plot_time_series(y, title="Tourism Quarterly: Visits by Region")
     return (y,)
 
 

--- a/examples/search_visualization.py
+++ b/examples/search_visualization.py
@@ -56,12 +56,12 @@ def _():
     from optuna.distributions import CategoricalDistribution, FloatDistribution
     from sklearn.linear_model import Ridge
 
-    from yohou.datasets import load_vic_electricity
+    from yohou.datasets import fetch_electricity_demand
     from yohou.metrics import MeanAbsoluteError
     from yohou.plotting import (
         plot_cv_results_scatter,
         plot_forecast,
-        plot_residual_time_series,
+        plot_residuals,
         plot_time_series,
     )
     from yohou.point import PointReductionForecaster
@@ -78,12 +78,12 @@ def _():
         PointReductionForecaster,
         Ridge,
         Sampler,
-        load_vic_electricity,
+        fetch_electricity_demand,
         optuna,
         pl,
         plot_cv_results_scatter,
         plot_forecast,
-        plot_residual_time_series,
+        plot_residuals,
         plot_time_series,
     )
 
@@ -94,18 +94,18 @@ def _(mo):
         r"""
         ## 1. Load and Explore the Data
 
-        The Victoria Electricity dataset contains 30-minute measurements of
-        electricity demand and temperature. We use a subset of the Demand column
-        to keep the search fast.
+        The Australian Electricity Demand dataset contains 30-minute measurements
+        of electricity demand across multiple states. We use a subset of Victoria's
+        demand column to keep the search fast.
         """
     )
     return
 
 
 @app.cell
-def _(load_vic_electricity, pl):
-    y_full = load_vic_electricity()
-    y_all = y_full.select(["time", "Demand"]).head(500)
+def _(fetch_electricity_demand, pl):
+    y_full = fetch_electricity_demand().frame
+    y_all = y_full.select(["time", "vic__demand"]).rename({"vic__demand": "demand"}).head(500)
     plot_time_series_fig = None
     return y_all, y_full
 
@@ -296,8 +296,8 @@ def _(plot_forecast, y_pred, y_test, y_train):
 
 
 @app.cell
-def _(plot_residual_time_series, y_pred, y_test):
-    plot_residual_time_series(
+def _(plot_residuals, y_pred, y_test):
+    plot_residuals(
         y_pred,
         y_test,
         title="Forecast Residuals",
@@ -316,7 +316,7 @@ def _(mo):
         - **`plot_param_importances`** identifies which hyperparameters matter most
         - **`plot_slice` and `plot_contour`** show individual and joint parameter effects
         - **`plot_cv_results_scatter`** from yohou visualizes score vs parameter values
-        - **`plot_forecast` and `plot_residual_time_series`** provide forecast-level diagnostics
+        - **`plot_forecast` and `plot_residuals`** provide forecast-level diagnostics
 
         ## Next Steps
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,7 @@ addopts = [
 filterwarnings = [
     "error",
     "ignore::ResourceWarning",
+    "ignore:Support for the dataframe interchange protocol:DeprecationWarning",
 ]
 markers = [
     "integration: marks tests as integration tests that run subprocesses (deselect with '-m \"not integration\"')",

--- a/src/yohou_optuna/objective.py
+++ b/src/yohou_optuna/objective.py
@@ -44,8 +44,8 @@ class _Objective:
         Scoring functions.
     fit_params : dict
         Additional parameters passed to ``forecaster.fit()``.
-    predict_params : dict
-        Additional parameters passed to ``forecaster.predict()``.
+    predict_func_params : dict
+        Additional parameters passed to ``forecaster.predict()`` or ``forecaster.predict_interval()``.
     score_params : dict
         Additional parameters passed to scorer.
     verbose : int, default=0
@@ -58,6 +58,9 @@ class _Objective:
         Whether multiple metrics are being optimized.
     refit : bool or str, default=True
         Primary metric name for multi-metric optimization.
+    coverage_rates : list of float or None, default=None
+        Coverage rates for interval forecasters.  Passed to
+        ``forecaster.fit()``.
 
     Notes
     -----
@@ -86,7 +89,7 @@ class _Objective:
         cv: Any,
         scorers: BaseScorer | _MultimetricScorer,
         fit_params: dict[str, Any],
-        predict_params: dict[str, Any],
+        predict_func_params: dict[str, Any],
         score_params: dict[str, Any],
         *,
         verbose: int = 0,
@@ -94,6 +97,7 @@ class _Objective:
         error_score: float | str = np.nan,
         multimetric: bool = False,
         refit: bool | str = True,
+        coverage_rates: list[float] | None = None,
     ) -> None:
         self.forecaster = forecaster
         self.param_distributions = param_distributions
@@ -103,13 +107,14 @@ class _Objective:
         self.cv = cv
         self.scorers = scorers
         self.fit_params = fit_params
-        self.predict_params = predict_params
+        self.predict_func_params = predict_func_params
         self.score_params = score_params
         self.verbose = verbose
         self.return_train_score = return_train_score
         self.error_score = error_score
         self.multimetric = multimetric
         self.refit = refit
+        self.coverage_rates = coverage_rates
 
     def __call__(self, trial: optuna.trial.Trial) -> float:
         """Evaluate a single trial.
@@ -221,6 +226,8 @@ class _Objective:
             try:
                 # Fit
                 fit_start = time.time()
+                if self.coverage_rates is not None:
+                    fit_params["coverage_rates"] = self.coverage_rates
                 fold_forecaster.fit(
                     y=y_train,
                     X=X_train,
@@ -237,7 +244,7 @@ class _Objective:
                     y_train,
                     y_test,
                     X_test,
-                    self.predict_params,
+                    self.predict_func_params,
                     self.scorers,
                     score_params_test,
                     self.error_score,
@@ -259,7 +266,7 @@ class _Objective:
                         y_train_reset,
                         y_train_test,
                         X_train_test,
-                        self.predict_params,
+                        self.predict_func_params,
                         self.scorers,
                         score_params_train,
                         self.error_score,

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -20,12 +20,11 @@ from yohou.model_selection.split import check_cv
 from yohou.model_selection.utils import (
     _collect_coverage_rates,
     _needs_interval_predictions,
-    _validate_forecaster_scorer_compatibility,
 )
 from yohou.utils import validate_search_data
 
 from .objective import _Objective
-from .utils import _build_cv_results
+from .utils import _build_cv_results, _validate_forecaster_scorer_compatibility
 
 
 # TODO: Check reference and make it mkdocs-compatible
@@ -308,9 +307,7 @@ class OptunaSearchCV(BaseSearchCV):
 
         # Route predict_params for interval or point prediction
         predict_func_params = (
-            routed_params.forecaster.predict_interval
-            if needs_interval
-            else routed_params.forecaster.predict
+            routed_params.forecaster.predict_interval if needs_interval else routed_params.forecaster.predict
         )
 
         # Create objective

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -17,12 +17,18 @@ from sklearn.utils.validation import _check_method_params, indexable
 from sklearn_optuna.optuna import Callback, Sampler, Storage
 from yohou.model_selection.search import BaseSearchCV
 from yohou.model_selection.split import check_cv
+from yohou.model_selection.utils import (
+    _collect_coverage_rates,
+    _needs_interval_predictions,
+    _validate_forecaster_scorer_compatibility,
+)
 from yohou.utils import validate_search_data
 
 from .objective import _Objective
 from .utils import _build_cv_results
 
 
+# TODO: Check reference and make it mkdocs-compatible
 class OptunaSearchCV(BaseSearchCV):
     """Hyperparameter search using Optuna optimization for Yohou forecasters.
 
@@ -95,8 +101,8 @@ class OptunaSearchCV(BaseSearchCV):
 
     See Also
     --------
-    yohou.model_selection.GridSearchCV : Exhaustive grid search.
-    yohou.model_selection.RandomizedSearchCV : Randomized search.
+    `yohou.model_selection.GridSearchCV` : Exhaustive grid search.
+    `yohou.model_selection.RandomizedSearchCV` : Randomized search.
 
     References
     ----------
@@ -236,6 +242,8 @@ class OptunaSearchCV(BaseSearchCV):
 
         scorers, refit_metric = self._get_scorers()
 
+        _validate_forecaster_scorer_compatibility(self.forecaster, scorers)
+
         y, X = indexable(y, X)
         params = _check_method_params(y, params=params)
 
@@ -250,6 +258,10 @@ class OptunaSearchCV(BaseSearchCV):
                     f"Expected optuna.distributions.BaseDistribution, got {type(distribution)}."
                 )
                 raise ValueError(msg)
+
+        # Determine interval prediction needs
+        needs_interval = _needs_interval_predictions(scorers)
+        coverage_rates = _collect_coverage_rates(scorers) if needs_interval else None
 
         # Get routed params
         routed_params = self._get_routed_params_for_fit(params)
@@ -294,6 +306,13 @@ class OptunaSearchCV(BaseSearchCV):
                 storage=storage_instance,
             )
 
+        # Route predict_params for interval or point prediction
+        predict_func_params = (
+            routed_params.forecaster.predict_interval
+            if needs_interval
+            else routed_params.forecaster.predict
+        )
+
         # Create objective
         objective = _Objective(
             forecaster=self.forecaster,
@@ -304,13 +323,14 @@ class OptunaSearchCV(BaseSearchCV):
             cv=cv_orig,
             scorers=scorers,
             fit_params=routed_params.forecaster.fit,
-            predict_params=routed_params.forecaster.predict,
+            predict_func_params=predict_func_params,
             score_params=routed_params.scorer.score,
             verbose=self.verbose,
             return_train_score=self.return_train_score,
             error_score=self.error_score,
             multimetric=self.multimetric_,
             refit=self.refit,
+            coverage_rates=coverage_rates,
         )
 
         # Run optimization
@@ -347,8 +367,10 @@ class OptunaSearchCV(BaseSearchCV):
         if self.refit:
             self.best_forecaster_ = clone(self.forecaster).set_params(**clone(self.best_params_, safe=False))
             refit_start_time = time.time()
-            fit_params_filtered = {k: v for k, v in routed_params.forecaster.fit.items() if k not in ["y", "X"]}
-            self.best_forecaster_.fit(y, X, forecasting_horizon, **fit_params_filtered)
+            fit_params = dict(routed_params.forecaster.fit)
+            if coverage_rates is not None:
+                fit_params["coverage_rates"] = coverage_rates
+            self.best_forecaster_.fit(y, X, forecasting_horizon, **fit_params)
             self.refit_time_ = time.time() - refit_start_time
 
         return self

--- a/src/yohou_optuna/utils.py
+++ b/src/yohou_optuna/utils.py
@@ -7,6 +7,10 @@ from typing import Any
 import numpy as np
 import optuna
 from scipy.stats import rankdata
+from yohou.base import BaseForecaster
+from yohou.interval.base import BaseIntervalForecaster
+from yohou.metrics.base import BaseIntervalScorer, BaseScorer
+from yohou.model_selection.utils import _MultimetricScorer
 
 
 def _build_cv_results(
@@ -249,3 +253,37 @@ def _compute_rankings(results: dict[str, Any]) -> None:
         rank_key = f"rank_test{suffix}"
 
         results[rank_key] = ranks
+
+
+def _validate_forecaster_scorer_compatibility(
+    forecaster: BaseForecaster,
+    scorers: BaseScorer | _MultimetricScorer,
+) -> None:
+    """Validate that the forecaster supports the prediction type required by scorers.
+
+    Parameters
+    ----------
+    forecaster : BaseForecaster
+        The forecaster to validate.
+    scorers : BaseScorer or _MultimetricScorer
+        The scorer(s) that will be used for evaluation.
+
+    Raises
+    ------
+    TypeError
+        If interval scorers are used with a forecaster that does not support
+        ``predict_interval``.
+
+    """
+    if isinstance(scorers, _MultimetricScorer):
+        has_interval = any(isinstance(s, BaseIntervalScorer) for s in scorers._scorers.values())
+    else:
+        has_interval = isinstance(scorers, BaseIntervalScorer)
+
+    if has_interval and not isinstance(forecaster, BaseIntervalForecaster):
+        msg = (
+            f"Interval scorers require a forecaster that supports predict_interval, "
+            f"but {type(forecaster).__name__} does not. "
+            f"Use a BaseIntervalForecaster subclass instead."
+        )
+        raise TypeError(msg)

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -967,7 +967,7 @@ class TestObjective:
             cv=2,
             scorers=MeanAbsoluteError(),
             fit_params={},
-            predict_params={},
+            predict_func_params={},
             score_params={},
             return_train_score=False,
             error_score=0.0,
@@ -999,7 +999,7 @@ class TestObjective:
             cv=2,
             scorers=MeanAbsoluteError(),
             fit_params={},
-            predict_params={},
+            predict_func_params={},
             score_params={},
             return_train_score=False,
             error_score=np.nan,
@@ -1027,7 +1027,7 @@ class TestObjective:
             cv=2,
             scorers=MeanAbsoluteError(),
             fit_params={},
-            predict_params={},
+            predict_func_params={},
             score_params={},
             return_train_score=False,
             error_score="raise",
@@ -1054,7 +1054,7 @@ class TestObjective:
             cv=2,
             scorers=MeanAbsoluteError(),
             fit_params={},
-            predict_params={},
+            predict_func_params={},
             score_params={},
             return_train_score=False,
             error_score=np.nan,
@@ -1082,7 +1082,7 @@ class TestObjective:
             cv=2,
             scorers=MeanAbsoluteError(),
             fit_params={},
-            predict_params={},
+            predict_func_params={},
             score_params={},
             return_train_score=False,
             error_score=np.nan,
@@ -1111,7 +1111,7 @@ class TestObjective:
             cv=2,
             scorers=MeanAbsoluteError(),
             fit_params={},
-            predict_params={},
+            predict_func_params={},
             score_params={},
             return_train_score=False,
             error_score=np.nan,
@@ -1617,15 +1617,13 @@ class TestIntervalPrediction:
     @pytest.mark.slow
     def test_interval_forecaster_fit_and_predict(self, y_X_factory, default_sampler):
         """Test that interval forecaster can be fitted and make predictions."""
-        from sklearn.linear_model import QuantileRegressor
         from yohou.interval import IntervalReductionForecaster
 
-        # Use single target for QuantileRegressor compatibility
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
         search = OptunaSearchCV(
-            forecaster=IntervalReductionForecaster(estimator=QuantileRegressor(solver="highs")),
+            forecaster=IntervalReductionForecaster(),
             param_distributions={
-                "estimator__alpha": FloatDistribution(0.0, 1.0),
+                "estimator__estimator__alpha": FloatDistribution(0.0, 1.0),
             },
             scoring=MeanAbsoluteError(),
             sampler=default_sampler,
@@ -1633,9 +1631,44 @@ class TestIntervalPrediction:
             cv=2,
             refit=True,
         )
-        # This may fail due to QuantileRegressor requirements - mark as xfail if so
-        try:
+        search.fit(y, X, forecasting_horizon=3)
+        assert hasattr(search, "best_forecaster_")
+
+    @pytest.mark.slow
+    def test_interval_forecaster_with_interval_scorer(self, y_X_factory, default_sampler):
+        """Test that interval forecaster works with interval scorer and coverage_rates."""
+        from yohou.interval import IntervalReductionForecaster
+        from yohou.metrics import IntervalScore
+
+        y, X = y_X_factory(length=100, n_targets=1, n_features=2)
+        search = OptunaSearchCV(
+            forecaster=IntervalReductionForecaster(),
+            param_distributions={
+                "estimator__estimator__alpha": FloatDistribution(0.0, 1.0),
+            },
+            scoring=IntervalScore(coverage_rates=[0.1, 0.5, 0.9]),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit=True,
+        )
+        search.fit(y, X, forecasting_horizon=3)
+        assert hasattr(search, "best_forecaster_")
+
+    def test_point_forecaster_with_interval_scorer_raises(self, y_X_factory, default_sampler):
+        """Test that using an interval scorer with a point forecaster raises TypeError."""
+        from yohou.metrics import IntervalScore
+
+        y, X = y_X_factory(length=100, n_targets=1, n_features=2)
+        search = OptunaSearchCV(
+            forecaster=PointReductionForecaster(estimator=Ridge()),
+            param_distributions={
+                "estimator__alpha": FloatDistribution(0.01, 10.0),
+            },
+            scoring=IntervalScore(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+        )
+        with pytest.raises(TypeError, match="Interval scorers require a forecaster"):
             search.fit(y, X, forecasting_horizon=3)
-            assert hasattr(search, "best_forecaster_")
-        except ValueError:
-            pytest.skip("IntervalReductionForecaster not compatible with test data shape")


### PR DESCRIPTION
## Description

Add interval forecaster support to `OptunaSearchCV`. When interval scorers are detected, the search now routes predictions through `predict_interval` instead of `predict`, collects `coverage_rates` from scorers, and validates forecaster-scorer compatibility.

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Motivation and Context

Fixes #

## Checklist

- [x] My code follows the code style of this project
- [ ] I have run `just fix` to format my code
- [ ] I have run `just lint` to verify linting and type annotations
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] All new and existing tests passed
- [ ] My changes generate no new warnings

## Additional Notes

