### PR TITLE
feat!: upgrade to yohou 0.1.0a5 with class proba support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "optuna",
   "scipy",
   "sklearn-optuna",
-  "yohou",
+  "yohou>=0.1.0a5",
 ]
 
 [dependency-groups]

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -19,12 +19,13 @@ from yohou.model_selection.search import BaseSearchCV
 from yohou.model_selection.split import check_cv
 from yohou.model_selection.utils import (
     _collect_coverage_rates,
-    _needs_interval_predictions,
+    _resolve_response_method,
+    _validate_forecaster_scorer_compatibility,
 )
 from yohou.utils import validate_search_data
 
 from .objective import _Objective
-from .utils import _build_cv_results, _validate_forecaster_scorer_compatibility
+from .utils import _build_cv_results
 
 
 # TODO: Check reference and make it mkdocs-compatible
@@ -261,9 +262,9 @@ class OptunaSearchCV(BaseSearchCV):
                 )
                 raise ValueError(msg)
 
-        # Determine interval prediction needs
-        needs_interval = _needs_interval_predictions(scorers)
-        coverage_rates = _collect_coverage_rates(scorers) if needs_interval else None
+        # Determine prediction context from scorer response methods
+        response_method = _resolve_response_method(scorers)
+        coverage_rates = _collect_coverage_rates(scorers) if response_method == "predict_interval" else None
 
         # Get routed params
         routed_params = self._get_routed_params_for_fit(params)
@@ -308,10 +309,8 @@ class OptunaSearchCV(BaseSearchCV):
                 storage=storage_instance,
             )
 
-        # Route predict_params for interval or point prediction
-        predict_func_params = (
-            routed_params.forecaster.predict_interval if needs_interval else routed_params.forecaster.predict
-        )
+        # Route predict_params for the resolved response method
+        predict_func_params = getattr(routed_params.forecaster, response_method, {})
 
         # Create objective
         objective = _Objective(

--- a/src/yohou_optuna/utils.py
+++ b/src/yohou_optuna/utils.py
@@ -7,10 +7,6 @@ from typing import Any
 import numpy as np
 import optuna
 from scipy.stats import rankdata
-from yohou.base import BaseForecaster
-from yohou.interval.base import BaseIntervalForecaster
-from yohou.metrics.base import BaseIntervalScorer, BaseScorer
-from yohou.model_selection.utils import _MultimetricScorer
 
 
 def _build_cv_results(
@@ -253,37 +249,3 @@ def _compute_rankings(results: dict[str, Any]) -> None:
         rank_key = f"rank_test{suffix}"
 
         results[rank_key] = ranks
-
-
-def _validate_forecaster_scorer_compatibility(
-    forecaster: BaseForecaster,
-    scorers: BaseScorer | _MultimetricScorer,
-) -> None:
-    """Validate that the forecaster supports the prediction type required by scorers.
-
-    Parameters
-    ----------
-    forecaster : BaseForecaster
-        The forecaster to validate.
-    scorers : BaseScorer or _MultimetricScorer
-        The scorer(s) that will be used for evaluation.
-
-    Raises
-    ------
-    TypeError
-        If interval scorers are used with a forecaster that does not support
-        ``predict_interval``.
-
-    """
-    if isinstance(scorers, _MultimetricScorer):
-        has_interval = any(isinstance(s, BaseIntervalScorer) for s in scorers._scorers.values())
-    else:
-        has_interval = isinstance(scorers, BaseIntervalScorer)
-
-    if has_interval and not isinstance(forecaster, BaseIntervalForecaster):
-        msg = (
-            f"Interval scorers require a forecaster that supports predict_interval, "
-            f"but {type(forecaster).__name__} does not. "
-            f"Use a BaseIntervalForecaster subclass instead."
-        )
-        raise TypeError(msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -367,6 +367,58 @@ def interval_forecaster():
 
 
 @pytest.fixture
+def class_proba_forecaster():
+    """Create a ClassProbaReductionForecaster for class probability testing.
+
+    Returns
+    -------
+    ClassProbaReductionForecaster
+        A forecaster that supports class probability prediction.
+
+    """
+    from sklearn.linear_model import LogisticRegression
+    from yohou.class_proba import ClassProbaReductionForecaster
+    from yohou.compose import FeaturePipeline
+    from yohou.preprocessing import LagTransformer
+
+    return ClassProbaReductionForecaster(
+        estimator=LogisticRegression(),
+        reduction_strategy="direct",
+        feature_transformer=FeaturePipeline([("lag", LagTransformer(lag=[1, 2, 3]))]),
+    )
+
+
+@pytest.fixture
+def y_class_proba_factory():
+    """Factory for generating binary classification time series data.
+
+    Returns a callable that generates a polars DataFrame with a ``"time"``
+    column and binary class columns suitable for class probability
+    forecasters.
+
+    Returns
+    -------
+    callable
+        Factory function accepting length and seed parameters.
+
+    """
+
+    def _factory(length=100, seed=42):
+        rng = np.random.default_rng(seed)
+        time_col = pl.datetime_range(
+            start=datetime(2021, 12, 16),
+            end=datetime(2021, 12, 16) + timedelta(seconds=length - 1),
+            interval="1s",
+            eager=True,
+        )
+        classes = rng.choice([0.0, 1.0], size=length)
+        y = pl.DataFrame({"time": time_col, "label": classes})
+        return y
+
+    return _factory
+
+
+@pytest.fixture
 def large_param_distributions():
     """Create parameter distributions with many parameters for stress testing.
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1618,6 +1618,7 @@ class TestIntervalPrediction:
     def test_interval_forecaster_fit_and_predict(self, y_X_factory, default_sampler):
         """Test that interval forecaster can be fitted and make predictions."""
         from yohou.interval import IntervalReductionForecaster
+        from yohou.metrics import IntervalScore
 
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
         search = OptunaSearchCV(
@@ -1625,7 +1626,7 @@ class TestIntervalPrediction:
             param_distributions={
                 "estimator__estimator__alpha": FloatDistribution(0.0, 1.0),
             },
-            scoring=MeanAbsoluteError(),
+            scoring=IntervalScore(coverage_rates=[0.1, 0.5, 0.9]),
             sampler=default_sampler,
             n_trials=2,
             cv=2,
@@ -1656,7 +1657,7 @@ class TestIntervalPrediction:
         assert hasattr(search, "best_forecaster_")
 
     def test_point_forecaster_with_interval_scorer_raises(self, y_X_factory, default_sampler):
-        """Test that using an interval scorer with a point forecaster raises TypeError."""
+        """Test that using an interval scorer with a point forecaster raises ValueError."""
         from yohou.metrics import IntervalScore
 
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
@@ -1670,5 +1671,217 @@ class TestIntervalPrediction:
             n_trials=2,
             cv=2,
         )
-        with pytest.raises(TypeError, match="Interval scorers require a forecaster"):
+        with pytest.raises(ValueError, match="interval"):
             search.fit(y, X, forecasting_horizon=3)
+
+
+class TestClassProbaPrediction:
+    """Test class probability forecasting support."""
+
+    def test_class_proba_forecaster_fit_and_predict(
+        self, class_proba_forecaster, y_class_proba_factory, default_sampler
+    ):
+        """Test that class proba forecaster can be fitted and make predictions."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit=True,
+        )
+        search.fit(y, forecasting_horizon=3)
+        assert hasattr(search, "best_forecaster_")
+        assert hasattr(search, "best_params_")
+        assert hasattr(search, "best_score_")
+
+    def test_class_proba_predict_class_proba_after_fit(
+        self, class_proba_forecaster, y_class_proba_factory, default_sampler
+    ):
+        """Test predict_class_proba works after fit."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit=True,
+        )
+        search.fit(y, forecasting_horizon=3)
+        y_pred = search.predict_class_proba(forecasting_horizon=3)
+        assert y_pred is not None
+        assert len(y_pred) > 0
+
+    def test_class_proba_cv_results_structure(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
+        """Test cv_results_ has expected keys for class proba search."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=3,
+            cv=2,
+            refit=True,
+        )
+        search.fit(y, forecasting_horizon=3)
+
+        cv = search.cv_results_
+        assert "params" in cv
+        assert "mean_test_score" in cv
+        assert "rank_test_score" in cv
+        assert len(cv["params"]) == 3
+
+    def test_class_proba_multimetric(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
+        """Test multi-metric scoring with class proba scorers."""
+        from yohou.metrics.class_proba import Accuracy, BrierScore
+
+        y = y_class_proba_factory(length=100)
+        scoring = {
+            "brier": BrierScore(),
+            "accuracy": Accuracy(),
+        }
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=scoring,
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit="brier",
+        )
+        search.fit(y, forecasting_horizon=3)
+
+        assert search.multimetric_
+        assert "mean_test_brier" in search.cv_results_
+        assert "mean_test_accuracy" in search.cv_results_
+        assert "rank_test_brier" in search.cv_results_
+        assert "rank_test_accuracy" in search.cv_results_
+
+    def test_class_proba_with_train_score(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
+        """Test return_train_score with class proba forecaster."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit=True,
+            return_train_score=True,
+        )
+        search.fit(y, forecasting_horizon=3)
+
+        cv = search.cv_results_
+        assert "mean_train_score" in cv
+        assert "split0_train_score" in cv
+
+    def test_point_forecaster_with_class_proba_scorer_raises(self, y_X_factory, default_sampler):
+        """Test that using a class proba scorer with a point forecaster raises ValueError."""
+        y, X = y_X_factory(length=100, n_targets=1, n_features=2)
+        search = OptunaSearchCV(
+            forecaster=PointReductionForecaster(estimator=Ridge()),
+            param_distributions={
+                "estimator__alpha": FloatDistribution(0.01, 10.0),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+        )
+        with pytest.raises(ValueError, match="class"):
+            search.fit(y, X, forecasting_horizon=3)
+
+    def test_class_proba_forecaster_with_point_scorer_raises(
+        self, class_proba_forecaster, y_class_proba_factory, default_sampler
+    ):
+        """Test that using a point scorer with a class proba forecaster raises ValueError."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0),
+            },
+            scoring=MeanAbsoluteError(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+        )
+        with pytest.raises(ValueError, match="point"):
+            search.fit(y, forecasting_horizon=3)
+
+    def test_class_proba_refit_false(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
+        """Test refit=False with class proba forecaster."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit=False,
+        )
+        search.fit(y, forecasting_horizon=3)
+        assert not hasattr(search, "best_forecaster_")
+
+    def test_class_proba_best_params_applied(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
+        """Test that best params are correctly applied to the refitted forecaster."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=3,
+            cv=2,
+            refit=True,
+        )
+        search.fit(y, forecasting_horizon=3)
+
+        best_C = search.best_params_["estimator__C"]
+        assert search.best_forecaster_.get_params()["estimator__C"] == best_C
+
+    def test_class_proba_no_predict_interval(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
+        """Test that class proba forecaster does not expose predict_interval."""
+        y = y_class_proba_factory(length=100)
+        search = OptunaSearchCV(
+            forecaster=class_proba_forecaster,
+            param_distributions={
+                "estimator__C": FloatDistribution(0.01, 10.0, log=True),
+            },
+            scoring=self._brier_score(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+            refit=True,
+        )
+        search.fit(y, forecasting_horizon=3)
+
+        with pytest.raises(AttributeError):
+            search.predict_interval(forecasting_horizon=3)
+
+    @staticmethod
+    def _brier_score():
+        from yohou.metrics.class_proba import BrierScore
+
+        return BrierScore()


### PR DESCRIPTION
## Description

Upgrade yohou-optuna to be compatible with yohou 0.1.0a5 and add full class probability forecaster/scorer support.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

yohou 0.1.0a5 introduced class probability forecasters/scorers and replaced `_needs_interval_predictions` with a generalized `_resolve_response_method` dispatching system. This PR updates yohou-optuna to use the new API and sets `yohou>=0.1.0a5` as the minimum dependency.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Key changes:
- Replaced `_needs_interval_predictions` with `_resolve_response_method` for prediction method dispatching
- Removed local `_validate_forecaster_scorer_compatibility` in favor of yohou's version (which handles point, interval, and class_proba validation)
- Fixed interval test that used a point scorer with an interval-only forecaster
- Added 10 comprehensive class proba tests and 2 new test fixtures
