### PR TITLE
fix(utils): infer metric names from all completed trials

### DIFF
--- a/src/yohou_optuna/utils.py
+++ b/src/yohou_optuna/utils.py
@@ -51,7 +51,7 @@ def _build_cv_results(
         return {"params": []}
 
     # Infer metric names
-    metric_names = _infer_metric_names(completed_trials[0], multimetric)
+    metric_names = _infer_metric_names(completed_trials, multimetric)
 
     # Initialize result arrays
     results = _initialize_result_arrays(completed_trials, n_trials, metric_names, return_train_score)
@@ -65,13 +65,17 @@ def _build_cv_results(
     return results
 
 
-def _infer_metric_names(trial: optuna.trial.FrozenTrial, multimetric: bool) -> list[str]:
+def _infer_metric_names(trials: list[optuna.trial.FrozenTrial], multimetric: bool) -> list[str]:
     """Infer metric names from trial user attributes.
+
+    Searches through all completed trials to find metric names,
+    since error trials (completed but scored via ``error_score``)
+    may lack ``mean_test_`` attributes.
 
     Parameters
     ----------
-    trial : FrozenTrial
-        A completed trial to inspect for metric names.
+    trials : list of FrozenTrial
+        Completed trials to inspect for metric names.
     multimetric : bool
         Whether multiple metrics are expected.
 
@@ -82,13 +86,16 @@ def _infer_metric_names(trial: optuna.trial.FrozenTrial, multimetric: bool) -> l
 
     """
     if multimetric:
-        metric_names = []
-        for key in trial.user_attrs:
-            if key.startswith("mean_test_"):
-                metric_name = key[10:]  # len("mean_test_")
-                metric_names.append(metric_name)
-        metric_names.sort()
-        return metric_names
+        for trial in trials:
+            metric_names = []
+            for key in trial.user_attrs:
+                if key.startswith("mean_test_"):
+                    metric_name = key[10:]  # len("mean_test_")
+                    metric_names.append(metric_name)
+            if metric_names:
+                metric_names.sort()
+                return metric_names
+        return []
     else:
         return ["score"]
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1243,6 +1243,57 @@ class TestBuildCVResults:
         assert "std_test_score" in results
         assert "std_train_score" in results
 
+    def test_build_cv_results_error_trial_before_successful_multimetric(self, mocker):
+        """Test that metric names are inferred even when the first trial has no scores."""
+        from yohou_optuna.utils import _build_cv_results
+
+        # Error trial: completed but no mean_test_ attrs (exception before _store_scores)
+        error_trial = mocker.MagicMock()
+        error_trial.state = optuna.trial.TrialState.COMPLETE
+        error_trial.user_attrs = {
+            "param_estimator__alpha": 1.0,
+            "exception": "some error",
+            "exception_type": "ValueError",
+        }
+
+        # Successful trial with multi-metric scores
+        good_trial = mocker.MagicMock()
+        good_trial.state = optuna.trial.TrialState.COMPLETE
+        good_trial.user_attrs = {
+            "param_estimator__alpha": 2.0,
+            "mean_test_mae": -0.5,
+            "mean_test_rmse": -0.7,
+            "split0_test_mae": -0.4,
+            "split1_test_mae": -0.6,
+            "split0_test_rmse": -0.6,
+            "split1_test_rmse": -0.8,
+            "mean_fit_time": 0.1,
+            "std_fit_time": 0.01,
+            "mean_score_time": 0.05,
+            "std_score_time": 0.005,
+        }
+
+        results = _build_cv_results([error_trial, good_trial], multimetric=True, return_train_score=False)
+
+        assert "rank_test_mae" in results
+        assert "rank_test_rmse" in results
+
+    def test_build_cv_results_all_error_trials_multimetric(self, mocker):
+        """Test that all error trials produce empty metric names gracefully."""
+        from yohou_optuna.utils import _build_cv_results
+
+        error_trial = mocker.MagicMock()
+        error_trial.state = optuna.trial.TrialState.COMPLETE
+        error_trial.user_attrs = {
+            "param_estimator__alpha": 1.0,
+            "exception": "some error",
+        }
+
+        results = _build_cv_results([error_trial], multimetric=True, return_train_score=False)
+
+        assert "params" in results
+        assert len(results["params"]) == 1
+
 
 @pytest.mark.integration
 class TestIntegration:


### PR DESCRIPTION
## Description

Fix `_infer_metric_names` to search through all completed trials for metric names instead of only the first one. An error trial (completed but without score attributes) as the first trial caused an empty metric names list, so no `rank_test_*` keys were created in `cv_results_`, leading to a `KeyError` in `_select_best_index`.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

When using `OptunaSearchCV` with multi-metric scoring, if the first completed trial errors during cross-validation before `_store_scores` is called, `_infer_metric_names` returns an empty list because it only checked `completed_trials[0]` for `mean_test_*` attributes. This caused a `KeyError: 'rank_test_MeanAbsoluteError'` when `_select_best_index` tried to look up rankings.

## Checklist

- [x] My code follows the code style of this project
- [x] I have run `just fix` to format my code
- [x] I have run `just lint` to verify linting and type annotations
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings