### PR TITLE
feat: update API from X to X_actual, add X_future and X_forecast support

### DIFF
--- a/.github/skills/create-yohou-forecaster/SKILL.md
+++ b/.github/skills/create-yohou-forecaster/SKILL.md
@@ -44,8 +44,8 @@ Validation timing: (1) automatic at fit via `@_fit_context`, (2) domain-specific
 ## Panel Data Support
 
 ```python
-def fit(self, y, X, forecasting_horizon, **params):
-    y_t, X_t = self._pre_fit(y=y, X=X, forecasting_horizon=forecasting_horizon)
+def fit(self, y, X_actual, forecasting_horizon, *, X_future=None, X_forecast=None, **params):
+    y_t, X_t = self._pre_fit(y=y, X=X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast)
     if self.panel_group_names_ is not None:
         for col_name in self.local_y_schema_:
             pass  # Process each series (local_y_schema_ is dict[str, pl.DataType])
@@ -60,14 +60,14 @@ def fit(self, y, X, forecasting_horizon, **params):
 All forecasters MUST set at least one fitted attribute (trailing underscore `_`) in `fit()`:
 
 ```python
-def fit(self, y, X, forecasting_horizon, **params):
-    y_t, X_t = self._pre_fit(y=y, X=X, forecasting_horizon=forecasting_horizon)
+def fit(self, y, X_actual, forecasting_horizon, *, X_future=None, X_forecast=None, **params):
+    y_t, X_t = self._pre_fit(y=y, X=X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast)
 
     # Base class sets these automatically:
     # - self._forecasting_horizon
     # - self._observation_horizon
     # - self._y_observed (last observation_horizon rows)
-    # - self._X_observed (if X provided)
+    # - self._X_observed (if X_actual provided)
     # - self.panel_group_names_ (if panel data)
     # - self.local_y_schema_ (dict[str, pl.DataType], if panel data)
 

--- a/.github/skills/create-yohou-forecaster/forecaster_template.py
+++ b/.github/skills/create-yohou-forecaster/forecaster_template.py
@@ -66,8 +66,10 @@ class MyForecaster(BasePointForecaster):
     def fit(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
         forecasting_horizon: StrictInt = 1,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         **params,
     ) -> "MyForecaster":
         """Fit forecaster.
@@ -76,7 +78,7 @@ class MyForecaster(BasePointForecaster):
         ----------
         y : pl.DataFrame
             Target time series with "time" column.
-        X : pl.DataFrame, optional
+        X_actual : pl.DataFrame, optional
             Exogenous features with "time" column.
         forecasting_horizon : int, default=1
             Number of steps ahead to forecast.
@@ -88,7 +90,7 @@ class MyForecaster(BasePointForecaster):
         self
 
         """
-        y_t, X_t = self._pre_fit(y=y, X=X, forecasting_horizon=forecasting_horizon)
+        y_t, X_t = self._pre_fit(y=y, X=X_actual, forecasting_horizon=forecasting_horizon, X_future=X_future, X_forecast=X_forecast)
         # Your fitting logic using y_t, X_t (already transformed)
         # Must set at least one fitted attribute with trailing underscore
         self.fitted_attr_ = ...  # Example: self.model_, self.coefficients_, etc.
@@ -96,7 +98,8 @@ class MyForecaster(BasePointForecaster):
 
     def predict(
         self,
-        X: pl.DataFrame | None = None,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         forecasting_horizon: StrictInt | None = None,
         panel_group_names: list[str] | None = None,
         predict_transformed: bool = False,
@@ -106,8 +109,10 @@ class MyForecaster(BasePointForecaster):
 
         Parameters
         ----------
-        X : pl.DataFrame, optional
-            Exogenous features for forecast period (must have "time" column).
+        X_future : pl.DataFrame, optional
+            Known future features for forecast period.
+        X_forecast : pl.DataFrame, optional
+            External forecasts with vintage_time and time columns.
         forecasting_horizon : int, optional
             Number of steps ahead to forecast. If None, uses value from fit().
         panel_group_names : list of str, optional

--- a/.github/skills/create-yohou-forecaster/test_forecaster_template.py
+++ b/.github/skills/create-yohou-forecaster/test_forecaster_template.py
@@ -50,7 +50,7 @@ def test_forecaster_basic_fit_predict(y_X_factory):
     """Test basic fit and predict workflow."""
     y, X = y_X_factory(length=100)
     forecaster = MyForecaster(param1=1)
-    forecaster.fit(y[:80], X[:80] if X else None, forecasting_horizon=5)
+    forecaster.fit(y[:80], X_actual=X[:80] if X else None, forecasting_horizon=5)
 
     y_pred = forecaster.predict(forecasting_horizon=5)
 
@@ -64,10 +64,10 @@ def test_forecaster_observe_predict(y_X_factory):
     """Test observe_predict workflow."""
     y, X = y_X_factory(length=100)
     forecaster = MyForecaster(param1=1)
-    forecaster.fit(y[:80], X[:80] if X else None, forecasting_horizon=5)
+    forecaster.fit(y[:80], X_actual=X[:80] if X else None, forecasting_horizon=5)
 
     # Observe new data and predict
-    y_pred = forecaster.observe_predict(y[80:85], X[80:85] if X else None)
+    y_pred = forecaster.observe_predict(y[80:85], X_actual=X[80:85] if X else None)
     assert len(y_pred) == 5
 
 
@@ -75,7 +75,7 @@ def test_forecaster_panel_data(y_X_factory):
     """Test forecaster handles panel data (prefixed columns)."""
     y, X = y_X_factory(length=100, n_targets=2, seed=42, panel=True)
     forecaster = MyForecaster(param1=1)
-    forecaster.fit(y[:80], X[:80] if X else None, forecasting_horizon=5)
+    forecaster.fit(y[:80], X_actual=X[:80] if X else None, forecasting_horizon=5)
 
     y_pred = forecaster.predict(forecasting_horizon=5)
 

--- a/.github/skills/create-yohou-search/SKILL.md
+++ b/.github/skills/create-yohou-search/SKILL.md
@@ -45,7 +45,7 @@ search = GridSearchCV(
     scoring=MeanAbsoluteError(),
     cv=ExpandingWindowSplitter(n_splits=5),
 )
-search.fit(y, X, forecasting_horizon=3)
+search.fit(y, X_actual=X, forecasting_horizon=3)
 print(search.best_params_)
 ```
 
@@ -64,7 +64,7 @@ search = RandomizedSearchCV(
     n_iter=20,
     scoring=MeanAbsoluteError(),
 )
-search.fit(y, X, forecasting_horizon=3)
+search.fit(y, X_actual=X, forecasting_horizon=3)
 ```
 
 ---

--- a/.github/skills/create-yohou-search/test_search_template.py
+++ b/.github/skills/create-yohou-search/test_search_template.py
@@ -56,7 +56,7 @@ def test_search_basic_fit(y_X_factory):
         param_space={"estimator__alpha": [0.1, 1.0, 10.0]},
         scoring=MeanAbsoluteError(),
     )
-    search.fit(y, X, forecasting_horizon=5)
+    search.fit(y, X_actual=X, forecasting_horizon=5)
 
     assert hasattr(search, "best_params_")
     assert hasattr(search, "best_score_")
@@ -72,7 +72,7 @@ def test_search_predict(y_X_factory):
         param_space={"estimator__alpha": [0.1, 1.0]},
         scoring=MeanAbsoluteError(),
     )
-    search.fit(y[:80], X[:80], forecasting_horizon=5)
+    search.fit(y[:80], X_actual=X[:80], forecasting_horizon=5)
     y_pred = search.predict(forecasting_horizon=5)
 
     assert len(y_pred) == 5
@@ -89,7 +89,7 @@ def test_search_best_params_valid(y_X_factory):
         param_space=param_space,
         scoring=MeanAbsoluteError(),
     )
-    search.fit(y, X, forecasting_horizon=5)
+    search.fit(y, X_actual=X, forecasting_horizon=5)
 
     assert search.best_params_["estimator__alpha"] in param_space["estimator__alpha"]
 
@@ -103,7 +103,7 @@ def test_search_cv_results(y_X_factory):
         param_space={"estimator__alpha": [0.1, 1.0]},
         scoring=MeanAbsoluteError(),
     )
-    search.fit(y, X, forecasting_horizon=5)
+    search.fit(y, X_actual=X, forecasting_horizon=5)
 
     assert hasattr(search, "cv_results_")
     assert len(search.cv_results_) >= 2
@@ -118,7 +118,7 @@ def test_search_clone(y_X_factory):
         param_space={"estimator__alpha": [0.1, 1.0]},
         scoring=MeanAbsoluteError(),
     )
-    search.fit(y, X, forecasting_horizon=5)
+    search.fit(y, X_actual=X, forecasting_horizon=5)
 
     cloned = clone(search)
     assert not hasattr(cloned, "best_params_")

--- a/.github/skills/create-yohou-splitter/SKILL.md
+++ b/.github/skills/create-yohou-splitter/SKILL.md
@@ -25,7 +25,7 @@ description: "Step-by-step guide for implementing new time series cross-validati
 ### Expanding Window (Training Set Grows)
 
 ```python
-def split(self, y, X=None):
+def split(self, y, X_actual=None):
     n_samples = len(y)
     test_size = self.test_size or n_samples // (self.n_splits + 1)
 
@@ -40,7 +40,7 @@ def split(self, y, X=None):
 ### Sliding Window (Fixed Training Size)
 
 ```python
-def split(self, y, X=None):
+def split(self, y, X_actual=None):
     n_samples = len(y)
     test_size = self.test_size or n_samples // (self.n_splits + 1)
     train_size = self.train_size or n_samples - (self.n_splits * test_size)
@@ -64,7 +64,7 @@ _parameter_constraints: dict = {
     "gap": [Interval(numbers.Integral, 0, None, closed="left"), None],
 }
 
-def split(self, y, X=None):
+def split(self, y, X_actual=None):
     gap = self.gap or 0
     for i in range(self.n_splits):
         test_start = ...

--- a/.github/skills/create-yohou-splitter/splitter_template.py
+++ b/.github/skills/create-yohou-splitter/splitter_template.py
@@ -49,7 +49,7 @@ class MySplitter(BaseSplitter):
     def split(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
     ) -> Iterator[tuple[np.ndarray[Any, np.dtype[np.intp]], np.ndarray[Any, np.dtype[np.intp]]]]:
         """Generate indices to split time series data.
 
@@ -57,7 +57,7 @@ class MySplitter(BaseSplitter):
         ----------
         y : pl.DataFrame
             Target time series with mandatory "time" column.
-        X : pl.DataFrame, optional
+        X_actual : pl.DataFrame, optional
             Exogenous features (for signature compatibility, not used in splitting logic).
 
         Yields
@@ -69,11 +69,11 @@ class MySplitter(BaseSplitter):
 
         """
         # Validate data
-        y = validate_splitter_data(self, y=y, X=X)
+        y = validate_splitter_data(self, y=y, X=X_actual)
         _n_samples = len(y)  # noqa: F841
 
         # Generate test indices
-        for test_indices in self._iter_test_indices(y, X):
+        for test_indices in self._iter_test_indices(y, X_actual):
             # Compute train indices (all indices before test start)
             train_indices = np.arange(0, test_indices[0])
             yield train_indices, test_indices
@@ -81,7 +81,7 @@ class MySplitter(BaseSplitter):
     def _iter_test_indices(
         self,
         y: pl.DataFrame,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
     ) -> Iterator[np.ndarray[Any, np.dtype[np.intp]]]:
         """Generate test indices for each split.
 
@@ -89,7 +89,7 @@ class MySplitter(BaseSplitter):
         ----------
         y : pl.DataFrame
             Target time series.
-        X : pl.DataFrame, optional
+        X_actual : pl.DataFrame, optional
             Exogenous features.
 
         Yields
@@ -110,7 +110,7 @@ class MySplitter(BaseSplitter):
     def get_n_splits(
         self,
         y: pl.DataFrame | None = None,
-        X: pl.DataFrame | None = None,
+        X_actual: pl.DataFrame | None = None,
     ) -> int:
         """Returns the number of splitting iterations in the cross-validator.
 
@@ -118,7 +118,7 @@ class MySplitter(BaseSplitter):
         ----------
         y : pl.DataFrame, optional
             Target time series.
-        X : pl.DataFrame, optional
+        X_actual : pl.DataFrame, optional
             Exogenous features.
 
         Returns

--- a/.github/skills/create-yohou-splitter/test_splitter_template.py
+++ b/.github/skills/create-yohou-splitter/test_splitter_template.py
@@ -30,7 +30,7 @@ def test_splitter_systematic_checks(
     expected_failures_set = set(expected_failures)
     tags = {"splitter_type": "expanding", "supports_panel_data": False}
 
-    for check_name, check_func, check_kwargs in _yield_yohou_splitter_checks(splitter, y, X, tags=tags):
+    for check_name, check_func, check_kwargs in _yield_yohou_splitter_checks(splitter, y, X_actual=X, tags=tags):
         if check_name in expected_failures_set:
             pytest.skip(f"Expected failure: {check_name}")
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,9 @@ Documentation = "https://yohou-optuna.readthedocs.io"
 Repository = "https://github.com/stateful-y/yohou-optuna"
 "Bug Tracker" = "https://github.com/stateful-y/yohou-optuna/issues"
 
+[tool.uv]
+sources = { yohou = { workspace = true } }
+
 [build-system]
 requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
   "optuna",
   "scipy",
   "sklearn-optuna",
-  "yohou>=0.1.0a5",
+  "yohou>=0.1.0a6",
 ]
 
 [dependency-groups]
@@ -69,9 +69,6 @@ Homepage = "https://github.com/stateful-y/yohou-optuna"
 Documentation = "https://yohou-optuna.readthedocs.io"
 Repository = "https://github.com/stateful-y/yohou-optuna"
 "Bug Tracker" = "https://github.com/stateful-y/yohou-optuna/issues"
-
-[tool.uv]
-sources = { yohou = { workspace = true } }
 
 [build-system]
 requires = ["hatchling", "hatch-vcs"]

--- a/src/yohou_optuna/objective.py
+++ b/src/yohou_optuna/objective.py
@@ -15,7 +15,7 @@ from sklearn.utils.metaestimators import _safe_split
 from sklearn.utils.validation import _check_method_params
 from yohou.base import BaseForecaster
 from yohou.metrics.base import BaseScorer
-from yohou.model_selection.utils import _MultimetricScorer, _score
+from yohou.model_selection.utils import _MultimetricScorer, _score, _split_forecast_data
 
 
 class _Objective:
@@ -34,8 +34,13 @@ class _Objective:
         Dictionary mapping parameter names to Optuna distributions.
     y : pl.DataFrame
         Target time series with a ``"time"`` column.
-    X : pl.DataFrame or None
-        Feature time series with a ``"time"`` column.
+    X_actual : pl.DataFrame or None
+        Actual observation features with a ``"time"`` column.
+    X_future : pl.DataFrame or None
+        Known future features with a ``"time"`` column.
+    X_forecast : pl.DataFrame or None
+        External forecasts with ``"vintage_time"`` and ``"time"``
+        columns.
     forecasting_horizon : int
         Number of steps ahead to forecast.
     cv : BaseSplitter
@@ -84,7 +89,9 @@ class _Objective:
         forecaster: BaseForecaster,
         param_distributions: dict[str, Any],
         y: pl.DataFrame,
-        X: pl.DataFrame | None,
+        X_actual: pl.DataFrame | None,
+        X_future: pl.DataFrame | None,
+        X_forecast: pl.DataFrame | None,
         forecasting_horizon: int,
         cv: Any,
         scorers: BaseScorer | _MultimetricScorer,
@@ -102,7 +109,9 @@ class _Objective:
         self.forecaster = forecaster
         self.param_distributions = param_distributions
         self.y = y
-        self.X = X
+        self.X_actual = X_actual
+        self.X_future = X_future
+        self.X_forecast = X_forecast
         self.forecasting_horizon = forecasting_horizon
         self.cv = cv
         self.scorers = scorers
@@ -207,7 +216,7 @@ class _Objective:
         cloned_forecaster = clone(self.forecaster)
         cloned_forecaster.set_params(**params)
 
-        splits = list(self.cv.split(self.y, self.X))
+        splits = list(self.cv.split(self.y, self.X_actual))
         all_test_scores: list[dict[str, float | str] | float | str] = []
         all_train_scores: list[dict[str, float | str] | float | str] = []
         all_fit_times: list[float] = []
@@ -216,8 +225,11 @@ class _Objective:
         for _split_idx, (train, test) in enumerate(splits):
             fold_forecaster = clone(cloned_forecaster)
 
-            y_train, X_train = _safe_split(fold_forecaster, self.y, self.X, train)
-            y_test, X_test = _safe_split(fold_forecaster, self.y, self.X, test, train)
+            y_train, X_train = _safe_split(fold_forecaster, self.y, self.X_actual, train)
+            y_test, X_test = _safe_split(fold_forecaster, self.y, self.X_actual, test, train)
+            X_forecast_train, X_forecast_test = _split_forecast_data(
+                self.X_forecast, self.y, train, test,
+            )
 
             # Adjust fit_params for this split
             fit_params = _check_method_params(self.y, params=self.fit_params, indices=train)
@@ -230,8 +242,10 @@ class _Objective:
                     fit_params["coverage_rates"] = self.coverage_rates
                 fold_forecaster.fit(
                     y=y_train,
-                    X=X_train,
+                    X_actual=X_train,
                     forecasting_horizon=self.forecasting_horizon,
+                    X_future=self.X_future,
+                    X_forecast=X_forecast_train,
                     **fit_params,
                 )
                 fit_time = time.time() - fit_start
@@ -248,6 +262,8 @@ class _Objective:
                     self.scorers,
                     score_params_test,
                     self.error_score,
+                    X_future=self.X_future,
+                    X_forecast=X_forecast_test,
                 )
                 score_time = time.time() - score_start
                 all_score_times.append(score_time)
@@ -260,7 +276,12 @@ class _Objective:
                     test_reset = train[-len(test) :]
                     y_train_reset, X_train_reset = _safe_split(fold_forecaster, y_train, X_train, train_reset)
                     y_train_test, X_train_test = _safe_split(fold_forecaster, y_train, X_train, test_reset, train_reset)
-                    fold_forecaster.rewind(y_train_reset, X_train_reset)
+                    fold_forecaster.rewind(
+                        y_train_reset,
+                        X_actual=X_train_reset,
+                        X_future=self.X_future,
+                        X_forecast=X_forecast_train,
+                    )
                     train_scores = _score(
                         fold_forecaster,
                         y_train_reset,
@@ -270,6 +291,8 @@ class _Objective:
                         self.scorers,
                         score_params_train,
                         self.error_score,
+                        X_future=self.X_future,
+                        X_forecast=X_forecast_train,
                     )
                     all_train_scores.append(train_scores)
 

--- a/src/yohou_optuna/objective.py
+++ b/src/yohou_optuna/objective.py
@@ -225,8 +225,8 @@ class _Objective:
         for _split_idx, (train, test) in enumerate(splits):
             fold_forecaster = clone(cloned_forecaster)
 
-            y_train, X_train = _safe_split(fold_forecaster, self.y, self.X_actual, train)
-            y_test, X_test = _safe_split(fold_forecaster, self.y, self.X_actual, test, train)
+            y_train, X_actual_train = _safe_split(fold_forecaster, self.y, self.X_actual, train)
+            y_test, X_actual_test = _safe_split(fold_forecaster, self.y, self.X_actual, test, train)
             X_forecast_train, X_forecast_test = _split_X_forecast(
                 self.X_forecast,
                 self.y,
@@ -245,7 +245,7 @@ class _Objective:
                     fit_params["coverage_rates"] = self.coverage_rates
                 fold_forecaster.fit(
                     y=y_train,
-                    X_actual=X_train,
+                    X_actual=X_actual_train,
                     forecasting_horizon=self.forecasting_horizon,
                     X_future=self.X_future,
                     X_forecast=X_forecast_train,
@@ -260,7 +260,7 @@ class _Objective:
                     fold_forecaster,
                     y_train,
                     y_test,
-                    X_test,
+                    X_actual_test,
                     self.predict_func_params,
                     self.scorers,
                     score_params_test,
@@ -277,11 +277,15 @@ class _Objective:
                     score_params_train = _check_method_params(self.y, params=self.score_params, indices=train)
                     train_reset = train[: -len(test)]
                     test_reset = train[-len(test) :]
-                    y_train_reset, X_train_reset = _safe_split(fold_forecaster, y_train, X_train, train_reset)
-                    y_train_test, X_train_test = _safe_split(fold_forecaster, y_train, X_train, test_reset, train_reset)
+                    y_train_reset, X_actual_train_reset = _safe_split(
+                        fold_forecaster, y_train, X_actual_train, train_reset
+                    )
+                    y_train_test, X_actual_train_test = _safe_split(
+                        fold_forecaster, y_train, X_actual_train, test_reset, train_reset
+                    )
                     fold_forecaster.rewind(
                         y_train_reset,
-                        X_actual=X_train_reset,
+                        X_actual=X_actual_train_reset,
                         X_future=self.X_future,
                         X_forecast=X_forecast_train,
                     )
@@ -289,7 +293,7 @@ class _Objective:
                         fold_forecaster,
                         y_train_reset,
                         y_train_test,
-                        X_train_test,
+                        X_actual_train_test,
                         self.predict_func_params,
                         self.scorers,
                         score_params_train,

--- a/src/yohou_optuna/objective.py
+++ b/src/yohou_optuna/objective.py
@@ -15,7 +15,7 @@ from sklearn.utils.metaestimators import _safe_split
 from sklearn.utils.validation import _check_method_params
 from yohou.base import BaseForecaster
 from yohou.metrics.base import BaseScorer
-from yohou.model_selection.utils import _MultimetricScorer, _score, _split_forecast_data
+from yohou.model_selection.utils import _MultimetricScorer, _score, _split_X_forecast
 
 
 class _Objective:
@@ -227,8 +227,11 @@ class _Objective:
 
             y_train, X_train = _safe_split(fold_forecaster, self.y, self.X_actual, train)
             y_test, X_test = _safe_split(fold_forecaster, self.y, self.X_actual, test, train)
-            X_forecast_train, X_forecast_test = _split_forecast_data(
-                self.X_forecast, self.y, train, test,
+            X_forecast_train, X_forecast_test = _split_X_forecast(
+                self.X_forecast,
+                self.y,
+                train,
+                test,
             )
 
             # Adjust fit_params for this split

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -209,12 +209,11 @@ class OptunaSearchCV(BaseSearchCV):
 
     def fit(
         self,
-        y,
-        X_actual=None,
-        forecasting_horizon=1,
-        *,
-        X_future=None,
-        X_forecast=None,
+        y: pl.DataFrame,
+        X_actual: pl.DataFrame | None = None,
+        forecasting_horizon: int = 1,
+        X_future: pl.DataFrame | None = None,
+        X_forecast: pl.DataFrame | None = None,
         study=None,
         **params,
     ) -> OptunaSearchCV:

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -207,17 +207,32 @@ class OptunaSearchCV(BaseSearchCV):
         """
         raise NotImplementedError("OptunaSearchCV overrides fit() directly.")
 
-    def fit(self, y, X=None, forecasting_horizon=1, *, study=None, **params) -> OptunaSearchCV:
+    def fit(
+        self,
+        y,
+        X_actual=None,
+        forecasting_horizon=1,
+        *,
+        X_future=None,
+        X_forecast=None,
+        study=None,
+        **params,
+    ) -> OptunaSearchCV:
         """Run Optuna hyperparameter optimization.
 
         Parameters
         ----------
         y : pl.DataFrame
             Target time series with a ``"time"`` column.
-        X : pl.DataFrame or None, default=None
-            Exogenous features with a ``"time"`` column.
+        X_actual : pl.DataFrame or None, default=None
+            Actual observation features with a ``"time"`` column.
         forecasting_horizon : int, default=1
             Number of steps ahead to forecast.
+        X_future : pl.DataFrame or None, default=None
+            Known future features with a ``"time"`` column.
+        X_forecast : pl.DataFrame or None, default=None
+            External forecasts with ``"vintage_time"`` and ``"time"``
+            columns.
         study : optuna.study.Study or None, default=None
             An existing Optuna study to continue from.  If ``None``, a new
             study is created.
@@ -241,13 +256,13 @@ class OptunaSearchCV(BaseSearchCV):
         _raise_for_params(params, self, "fit")
 
         # Validate input data
-        validate_search_data(y, X)
+        validate_search_data(y, X_actual)
 
         scorers, refit_metric = self._get_scorers()
 
         _validate_forecaster_scorer_compatibility(self.forecaster, scorers)
 
-        y, X = indexable(y, X)
+        y, X_actual = indexable(y, X_actual)
         params = _check_method_params(y, params=params)
 
         self.scorer_ = scorers
@@ -271,7 +286,7 @@ class OptunaSearchCV(BaseSearchCV):
 
         # Get CV splitter
         cv_orig = check_cv(self.cv, forecasting_horizon)
-        self.n_splits_ = cv_orig.get_n_splits(y, X, **routed_params.splitter.split)
+        self.n_splits_ = cv_orig.get_n_splits(y, X_actual, **routed_params.splitter.split)
 
         # Instantiate sampler from wrapper
         sampler_instance = None
@@ -317,7 +332,9 @@ class OptunaSearchCV(BaseSearchCV):
             forecaster=self.forecaster,
             param_distributions=self.param_distributions,
             y=y,
-            X=X,
+            X_actual=X_actual,
+            X_future=X_future,
+            X_forecast=X_forecast,
             forecasting_horizon=forecasting_horizon,
             cv=cv_orig,
             scorers=scorers,
@@ -369,7 +386,14 @@ class OptunaSearchCV(BaseSearchCV):
             fit_params = dict(routed_params.forecaster.fit)
             if coverage_rates is not None:
                 fit_params["coverage_rates"] = coverage_rates
-            self.best_forecaster_.fit(y, X, forecasting_horizon, **fit_params)
+            self.best_forecaster_.fit(
+                y,
+                X_actual,
+                forecasting_horizon,
+                X_future=X_future,
+                X_forecast=X_forecast,
+                **fit_params,
+            )
             self.refit_time_ = time.time() - refit_start_time
 
         return self

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -7,6 +7,7 @@ from numbers import Integral, Real
 
 import numpy as np
 import optuna
+import polars as pl
 from optuna.distributions import BaseDistribution
 from sklearn.base import clone
 from sklearn.utils._param_validation import Interval

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -215,7 +215,7 @@ class OptunaSearchCV(BaseSearchCV):
         forecasting_horizon: int = 1,
         X_future: pl.DataFrame | None = None,
         X_forecast: pl.DataFrame | None = None,
-        study=None,
+        study: optuna.study.Study | None = None,
         **params,
     ) -> OptunaSearchCV:
         """Run Optuna hyperparameter optimization.

--- a/src/yohou_optuna/search.py
+++ b/src/yohou_optuna/search.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from numbers import Integral, Real
+from typing import Any
 
 import numpy as np
 import optuna
@@ -16,14 +18,17 @@ from sklearn.utils.metadata_routing import (
 )
 from sklearn.utils.validation import _check_method_params, indexable
 from sklearn_optuna.optuna import Callback, Sampler, Storage
+from yohou.base import BaseForecaster
+from yohou.metrics.base import BaseScorer
 from yohou.model_selection.search import BaseSearchCV
-from yohou.model_selection.split import check_cv
+from yohou.model_selection.split import BaseSplitter, check_cv
 from yohou.model_selection.utils import (
     _collect_coverage_rates,
     _resolve_response_method,
     _validate_forecaster_scorer_compatibility,
 )
 from yohou.utils import validate_search_data
+from yohou.utils.tags import Tags
 
 from .objective import _Objective
 from .utils import _build_cv_results
@@ -157,23 +162,23 @@ class OptunaSearchCV(BaseSearchCV):
 
     def __init__(
         self,
-        forecaster,
-        param_distributions,
+        forecaster: BaseForecaster,
+        param_distributions: dict[str, BaseDistribution],
         *,
-        scoring=None,
-        sampler=None,
-        storage=None,
-        callbacks=None,
-        n_trials=10,
-        timeout=None,
-        n_jobs=None,
-        refit=True,
-        cv=None,
-        verbose=0,
-        pre_dispatch="2*n_jobs",
-        error_score=np.nan,
-        return_train_score=False,
-    ):
+        scoring: BaseScorer | dict[str, BaseScorer] | None = None,
+        sampler: Sampler | None = None,
+        storage: Storage | None = None,
+        callbacks: dict[str, Callback] | None = None,
+        n_trials: int | None = 10,
+        timeout: float | None = None,
+        n_jobs: int | None = None,
+        refit: bool | str | Callable[..., int] = True,
+        cv: int | BaseSplitter | None = None,
+        verbose: int = 0,
+        pre_dispatch: int | str = "2*n_jobs",
+        error_score: float | str = np.nan,
+        return_train_score: bool = False,
+    ) -> None:
         super().__init__(
             forecaster=forecaster,
             scoring=scoring,
@@ -192,7 +197,7 @@ class OptunaSearchCV(BaseSearchCV):
         self.timeout = timeout
         self.callbacks = callbacks
 
-    def _run_search(self, evaluate_candidates):
+    def _run_search(self, evaluate_candidates: Callable[..., Any]) -> None:
         """Not used. OptunaSearchCV overrides fit() directly.
 
         Parameters
@@ -398,7 +403,7 @@ class OptunaSearchCV(BaseSearchCV):
 
         return self
 
-    def __sklearn_tags__(self):
+    def __sklearn_tags__(self) -> Tags:
         """Get tags for this search estimator.
 
         Adds ``search_type = "optuna"`` to the tags returned by

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -280,15 +280,15 @@ class FailingForecaster(BaseForecaster):
         self.fail_on = fail_on
         self.exception_cls = exception_cls
 
-    def fit(self, y, X=None, forecasting_horizon=1, **fit_params):
+    def fit(self, y, X_actual=None, forecasting_horizon=1, **fit_params):
         """Raise if fail_on includes fit.
 
         Parameters
         ----------
         y : pl.DataFrame
             Target time series.
-        X : pl.DataFrame or None, default=None
-            Exogenous features.
+        X_actual : pl.DataFrame or None, default=None
+            Actual observation features.
         forecasting_horizon : int, default=1
             Forecast horizon.
         **fit_params : dict
@@ -310,15 +310,13 @@ class FailingForecaster(BaseForecaster):
         self.is_fitted_ = True
         return self
 
-    def predict(self, forecasting_horizon=None, X=None, **predict_params):
+    def predict(self, forecasting_horizon=None, **predict_params):
         """Raise if fail_on includes predict.
 
         Parameters
         ----------
         forecasting_horizon : int or None, default=None
             Number of steps to forecast.
-        X : pl.DataFrame or None, default=None
-            Exogenous features.
         **predict_params : dict
             Additional parameters.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,11 +310,15 @@ class FailingForecaster(BaseForecaster):
         self.is_fitted_ = True
         return self
 
-    def predict(self, forecasting_horizon=None, **predict_params):
+    def predict(self, X_future=None, X_forecast=None, forecasting_horizon=None, **predict_params):
         """Raise if fail_on includes predict.
 
         Parameters
         ----------
+        X_future : pl.DataFrame or None, default=None
+            Known future features.
+        X_forecast : pl.DataFrame or None, default=None
+            External forecasts.
         forecasting_horizon : int or None, default=None
             Number of steps to forecast.
         **predict_params : dict

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -54,7 +54,7 @@ class TestOptunaSearchCVSystematicChecks:
         )
 
         search_cv_fitted = clone(search_cv)
-        search_cv_fitted.fit(y_train, X_train, forecasting_horizon=3)
+        search_cv_fitted.fit(y_train, X_actual=X_train, forecasting_horizon=3)
 
         tags = {
             "search_type": "optuna",
@@ -76,7 +76,7 @@ class TestOptunaSearchCVFit:
     def test_fit_with_valid_data_sets_required_attributes(self, optuna_search_cv, y_X_factory):
         """Test that fit runs and sets required attributes."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert hasattr(optuna_search_cv, "cv_results_")
         assert hasattr(optuna_search_cv, "best_params_")
@@ -105,7 +105,7 @@ class TestOptunaSearchCVFit:
     def test_predict_after_fit_returns_forecasts(self, optuna_search_cv, y_X_factory):
         """Test predict works after fit."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
         y_pred = optuna_search_cv.predict(forecasting_horizon=3)
         assert y_pred is not None
         assert len(y_pred) > 0
@@ -123,7 +123,7 @@ class TestCVResults:
     def test_cv_results_keys(self, optuna_search_cv, y_X_factory):
         """Test cv_results_ contains expected keys."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv_results = optuna_search_cv.cv_results_
         assert "params" in cv_results
@@ -138,7 +138,7 @@ class TestCVResults:
     def test_cv_results_param_keys(self, optuna_search_cv, y_X_factory):
         """Test cv_results_ contains parameter columns."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv_results = optuna_search_cv.cv_results_
         assert "param_estimator__alpha" in cv_results
@@ -146,7 +146,7 @@ class TestCVResults:
     def test_cv_results_split_keys(self, optuna_search_cv, y_X_factory):
         """Test cv_results_ contains per-split scores."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv_results = optuna_search_cv.cv_results_
         assert "split0_test_score" in cv_results
@@ -166,13 +166,13 @@ class TestCVResults:
             n_trials=n_trials,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert len(search.cv_results_["params"]) == n_trials
 
     def test_cv_results_rankings(self, optuna_search_cv, y_X_factory):
         """Test that rankings are valid (1-indexed, dense)."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         ranks = optuna_search_cv.cv_results_["rank_test_score"]
         assert np.min(ranks) == 1
@@ -185,14 +185,14 @@ class TestStudyAndTrials:
     def test_study_stored(self, optuna_search_cv, y_X_factory):
         """Test that study_ is stored after fit."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert isinstance(optuna_search_cv.study_, optuna.study.Study)
 
     def test_trials_stored(self, optuna_search_cv, y_X_factory):
         """Test that trials_ is stored after fit."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert isinstance(optuna_search_cv.trials_, list)
         assert len(optuna_search_cv.trials_) == optuna_search_cv.n_trials
@@ -214,11 +214,11 @@ class TestStudyAndTrials:
         )
 
         # First fit
-        search.fit(y, X, forecasting_horizon=3, study=study)
+        search.fit(y, X_actual=X, forecasting_horizon=3, study=study)
         first_n_trials = len(study.trials)
 
         # Continue with same study
-        search.fit(y, X, forecasting_horizon=3, study=study)
+        search.fit(y, X_actual=X, forecasting_horizon=3, study=study)
         assert len(study.trials) == first_n_trials + 2
 
 
@@ -243,7 +243,7 @@ class TestMultiMetric:
             refit="mae",
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert search.multimetric_
         assert "mean_test_mae" in search.cv_results_
@@ -269,7 +269,7 @@ class TestMultiMetric:
             refit="mae",
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert hasattr(search, "best_score_")
         assert search.best_score_ == search.cv_results_["mean_test_mae"][search.best_index_]
@@ -292,7 +292,7 @@ class TestMultiMetric:
             cv=2,
             return_train_score=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv = search.cv_results_
         assert "split0_train_mae" in cv
@@ -319,7 +319,7 @@ class TestMultiMetric:
             error_score=np.nan,
             refit=False,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv = search.cv_results_
         assert np.all(np.isnan(cv["mean_test_mae"]))
@@ -344,7 +344,7 @@ class TestMultiMetric:
             refit=False,
             return_train_score=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv = search.cv_results_
         assert np.all(np.isnan(cv["mean_train_mae"]))
@@ -367,7 +367,7 @@ class TestRefit:
             refit=False,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert not hasattr(search, "best_forecaster_")
         assert not hasattr(search, "refit_time_")
@@ -375,7 +375,7 @@ class TestRefit:
     def test_refit_true_creates_forecaster(self, optuna_search_cv, y_X_factory):
         """Test refit=True creates best_forecaster_."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert hasattr(optuna_search_cv, "best_forecaster_")
         assert hasattr(optuna_search_cv, "refit_time_")
@@ -396,7 +396,7 @@ class TestRefit:
             error_score=np.nan,
             refit=False,
         )
-        result = search.fit(y, X, forecasting_horizon=3)
+        result = search.fit(y, X_actual=X, forecasting_horizon=3)
         assert result is search
 
     def test_empty_results_with_refit_true_raises_error(self, default_sampler, mocker):
@@ -433,7 +433,7 @@ class TestRefit:
             )
             y = pl.DataFrame({"time": time_col, "y_0": np.random.rand(100)})
             X = pl.DataFrame({"time": time_col, "X_0": np.random.rand(100)})
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_empty_results_with_refit_false_returns_self(self, default_sampler, mocker):
         """Test that fit returns self when no trials complete and refit=False."""
@@ -469,7 +469,7 @@ class TestRefit:
         y = pl.DataFrame({"time": time_col, "y_0": np.random.rand(100)})
         X = pl.DataFrame({"time": time_col, "X_0": np.random.rand(100)})
 
-        result = search.fit(y, X, forecasting_horizon=3)
+        result = search.fit(y, X_actual=X, forecasting_horizon=3)
         assert result is search
 
     def test_callable_refit_skips_best_score(self, y_X_factory, default_sampler):
@@ -491,7 +491,7 @@ class TestRefit:
             cv=2,
             refit=custom_refit,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert hasattr(search, "best_forecaster_")
         assert hasattr(search, "best_params_")
@@ -514,7 +514,7 @@ class TestTrainScore:
             cv=2,
             return_train_score=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert "mean_train_score" in search.cv_results_
         assert "std_train_score" in search.cv_results_
@@ -523,7 +523,7 @@ class TestTrainScore:
     def test_no_train_score_by_default(self, optuna_search_cv, y_X_factory):
         """Test return_train_score=False by default."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert "mean_train_score" not in optuna_search_cv.cv_results_
 
@@ -542,7 +542,7 @@ class TestParameterValidation:
             cv=2,
         )
         with pytest.raises(ValueError, match="invalid distribution"):
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_clone_preserves_params(self, optuna_search_cv):
         """Test that clone preserves all constructor parameters."""
@@ -565,7 +565,7 @@ class TestParameterValidation:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert "param_estimator__alpha" in search.cv_results_
         assert "param_estimator__fit_intercept" in search.cv_results_
@@ -588,7 +588,7 @@ class TestParameterValidation:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
 
     def test_get_params_set_params_roundtrip(self, optuna_search_cv):
@@ -617,7 +617,7 @@ class TestParameterValidation:
             cv=2,
             n_jobs=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
         assert len(search.cv_results_["params"]) == 3
 
@@ -642,7 +642,7 @@ class TestErrorHandling:
             error_score=np.nan,
         )
         # Should not raise even if some trials fail
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_all_trials_fail_error_score_nan(self, y_X_factory, default_sampler, failing_forecaster):
         """Test that all-failing trials produce NaN scores with error_score=nan."""
@@ -659,7 +659,7 @@ class TestErrorHandling:
             error_score=np.nan,
             refit=False,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         # All trials should have NaN scores
         assert np.all(np.isnan(search.cv_results_["mean_test_score"]))
 
@@ -679,7 +679,7 @@ class TestErrorHandling:
             refit=False,
         )
         with pytest.raises(ValueError, match="intentional error"):
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_single_metric_error_with_train_score(self, default_sampler, y_X_factory):
         """Test error handling branch for single metric with return_train_score."""
@@ -689,7 +689,7 @@ class TestErrorHandling:
 
             _fit_count = 0
 
-            def fit(self, y, X=None, forecasting_horizon=None, **kwargs):
+            def fit(self, y, X_actual=None, forecasting_horizon=None, **kwargs):
                 """Raise on every fit call."""
                 FailOnSecondFitForecaster._fit_count += 1
                 raise RuntimeError("Intentional fit failure")
@@ -711,7 +711,7 @@ class TestErrorHandling:
         )
 
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert hasattr(search, "cv_results_")
         assert FailOnSecondFitForecaster._fit_count > 0
@@ -734,7 +734,7 @@ class TestSamplerAndCallbacks:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
 
     def test_timeout(self, y_X_factory, default_sampler):
@@ -751,7 +751,7 @@ class TestSamplerAndCallbacks:
             timeout=300,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
 
     def test_invalid_callbacks_type_raises(self, y_X_factory, default_sampler):
@@ -769,7 +769,7 @@ class TestSamplerAndCallbacks:
             callbacks=["not", "a", "dict"],
         )
         with pytest.raises(TypeError, match="callbacks must be a dict"):
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_invalid_callback_value_raises(self, y_X_factory, default_sampler):
         """Test that non-Callback values in callbacks dict raises TypeError."""
@@ -786,7 +786,7 @@ class TestSamplerAndCallbacks:
             callbacks={"bad": "not_a_callback"},
         )
         with pytest.raises(TypeError, match="must be a Callback instance"):
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_valid_callback(self, y_X_factory, default_sampler):
         """Test that valid callback runs without error."""
@@ -804,7 +804,7 @@ class TestSamplerAndCallbacks:
             cv=2,
             callbacks={"stop": Callback(callback=optuna.study.MaxTrialsCallback, n_trials=3)},
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
 
     def test_storage_wrapper(self, y_X_factory, default_sampler):
@@ -823,7 +823,7 @@ class TestSamplerAndCallbacks:
             cv=2,
             storage=Storage(storage=optuna.storages.InMemoryStorage),
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
 
     def test_fit_with_sampler_none_uses_default(self, y_X_factory):
@@ -840,7 +840,7 @@ class TestSamplerAndCallbacks:
             cv=2,
             refit=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
 
     def test_existing_study_with_sampler_none(self, y_X_factory):
@@ -858,7 +858,7 @@ class TestSamplerAndCallbacks:
             cv=2,
             refit=True,
         )
-        search.fit(y, X, forecasting_horizon=3, study=existing_study)
+        search.fit(y, X_actual=X, forecasting_horizon=3, study=existing_study)
         assert search.study_ is existing_study
 
 
@@ -878,7 +878,7 @@ class TestObjective:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         for trial in search.trials_:
             assert trial.state == optuna.trial.TrialState.COMPLETE
@@ -897,7 +897,7 @@ class TestObjective:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         for trial in search.trials_:
             assert "param_estimator__alpha" in trial.user_attrs
@@ -915,7 +915,7 @@ class TestObjective:
             n_trials=2,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         trial = search.trials_[0]
         assert "mean_fit_time" in trial.user_attrs
@@ -937,7 +937,7 @@ class TestObjective:
             n_trials=2,
             cv=3,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         trial = search.trials_[0]
         assert "split0_test_score" in trial.user_attrs
@@ -962,7 +962,9 @@ class TestObjective:
             forecaster=PointReductionForecaster(estimator=Ridge()),
             param_distributions={"estimator__alpha": FloatDistribution(0.01, 10.0)},
             y=None,
-            X=None,
+            X_actual=None,
+            X_future=None,
+            X_forecast=None,
             forecasting_horizon=3,
             cv=2,
             scorers=MeanAbsoluteError(),
@@ -994,7 +996,9 @@ class TestObjective:
             forecaster=PointReductionForecaster(estimator=Ridge()),
             param_distributions={"estimator__alpha": FloatDistribution(0.01, 10.0)},
             y=None,
-            X=None,
+            X_actual=None,
+            X_future=None,
+            X_forecast=None,
             forecasting_horizon=3,
             cv=2,
             scorers=MeanAbsoluteError(),
@@ -1022,7 +1026,9 @@ class TestObjective:
             forecaster=PointReductionForecaster(estimator=Ridge()),
             param_distributions={"estimator__alpha": FloatDistribution(0.01, 10.0)},
             y=None,
-            X=None,
+            X_actual=None,
+            X_future=None,
+            X_forecast=None,
             forecasting_horizon=3,
             cv=2,
             scorers=MeanAbsoluteError(),
@@ -1049,7 +1055,9 @@ class TestObjective:
             forecaster=PointReductionForecaster(estimator=Ridge()),
             param_distributions={"estimator__alpha": FloatDistribution(0.01, 10.0)},
             y=None,
-            X=None,
+            X_actual=None,
+            X_future=None,
+            X_forecast=None,
             forecasting_horizon=3,
             cv=2,
             scorers=MeanAbsoluteError(),
@@ -1077,7 +1085,9 @@ class TestObjective:
             forecaster=PointReductionForecaster(estimator=Ridge()),
             param_distributions={"estimator__alpha": FloatDistribution(0.01, 10.0)},
             y=None,
-            X=None,
+            X_actual=None,
+            X_future=None,
+            X_forecast=None,
             forecasting_horizon=3,
             cv=2,
             scorers=MeanAbsoluteError(),
@@ -1106,7 +1116,9 @@ class TestObjective:
             forecaster=PointReductionForecaster(estimator=Ridge()),
             param_distributions={"estimator__alpha": FloatDistribution(0.01, 10.0)},
             y=None,
-            X=None,
+            X_actual=None,
+            X_future=None,
+            X_forecast=None,
             forecasting_horizon=3,
             cv=2,
             scorers=MeanAbsoluteError(),
@@ -1147,7 +1159,7 @@ class TestBuildCVResults:
             n_trials=5,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv = search.cv_results_
         best_idx = np.argmax(cv["mean_test_score"])
@@ -1166,7 +1178,7 @@ class TestBuildCVResults:
             n_trials=4,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert len(search.cv_results_["params"]) == 4
         for params_dict in search.cv_results_["params"]:
@@ -1176,7 +1188,7 @@ class TestBuildCVResults:
     def test_std_test_score_is_nonnegative(self, optuna_search_cv, y_X_factory):
         """Test that std of test scores is non-negative."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         std_scores = optuna_search_cv.cv_results_["std_test_score"]
         assert np.all(std_scores >= 0)
@@ -1198,7 +1210,7 @@ class TestBuildCVResults:
             refit="mae",
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv = search.cv_results_
         assert "rank_test_mae" in cv
@@ -1318,7 +1330,7 @@ class TestIntegration:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         y_pred = search.predict(forecasting_horizon=3)
         assert y_pred is not None
         assert len(y_pred) > 0
@@ -1343,7 +1355,7 @@ class TestIntegration:
             refit="mae",
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert "mean_test_mae" in search.cv_results_
         assert "mean_test_rmse" in search.cv_results_
@@ -1355,7 +1367,7 @@ class TestIntegration:
     def test_fit_duration_tracked(self, optuna_search_cv, y_X_factory):
         """Test that refit_time_ is set and is positive."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert hasattr(optuna_search_cv, "refit_time_")
         assert isinstance(optuna_search_cv.refit_time_, float)
@@ -1364,7 +1376,7 @@ class TestIntegration:
     def test_study_direction_is_maximize(self, optuna_search_cv, y_X_factory):
         """Test that the optuna study direction is maximize."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert optuna_search_cv.study_.direction == optuna.study.StudyDirection.MAXIMIZE
 
@@ -1382,14 +1394,14 @@ class TestIntegration:
             n_trials=2,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         assert isinstance(search.study_.sampler, optuna.samplers.RandomSampler)
 
     def test_trial_states_all_complete(self, optuna_search_cv, y_X_factory):
         """Test that all trials have COMPLETE state."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         for trial in optuna_search_cv.trials_:
             assert trial.state == optuna.trial.TrialState.COMPLETE
@@ -1401,7 +1413,7 @@ class TestSklearnTags:
     def test_tags_from_fitted_forecaster(self, optuna_search_cv, y_X_factory):
         """Test that tags are delegated from best_forecaster_ after fit."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         tags = optuna_search_cv.__sklearn_tags__()
         assert tags is not None
@@ -1454,7 +1466,7 @@ class TestPanelData:
             n_trials=2,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_params_")
         assert hasattr(search, "cv_results_")
 
@@ -1471,7 +1483,7 @@ class TestPanelData:
             n_trials=3,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         cv_results = search.cv_results_
         assert len(cv_results["params"]) == 3
@@ -1492,7 +1504,7 @@ class TestPanelData:
             cv=2,
             refit=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         y_pred = search.predict(forecasting_horizon=3)
         assert y_pred is not None
         # Panel data should have columns for each group
@@ -1505,21 +1517,21 @@ class TestForecasterDelegation:
     def test_observe_delegates_to_best_forecaster(self, optuna_search_cv, y_X_factory):
         """Test that observe() delegates to best_forecaster_ after fit."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         # Get new data for observe
         y_new, X_new = y_X_factory(length=10, n_targets=1, n_features=2, seed=99)
-        result = optuna_search_cv.observe(y_new, X_new)
+        result = optuna_search_cv.observe(y_new, X_actual=X_new)
         assert result is optuna_search_cv
 
     def test_observe_predict_delegates_to_best_forecaster(self, optuna_search_cv, y_X_factory):
         """Test that observe_predict() delegates to best_forecaster_ after fit."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         # Get new data for observe_predict
         y_new, X_new = y_X_factory(length=10, n_targets=1, n_features=2, seed=99)
-        y_pred = optuna_search_cv.observe_predict(y_new, X_new, forecasting_horizon=3)
+        y_pred = optuna_search_cv.observe_predict(y_new, X_actual=X_new, forecasting_horizon=3)
         assert y_pred is not None
         assert len(y_pred) > 0
 
@@ -1527,13 +1539,13 @@ class TestForecasterDelegation:
         """Test that observe() before fit raises AttributeError."""
         y, X = y_X_factory(length=10, n_targets=1, n_features=2)
         with pytest.raises(AttributeError):
-            optuna_search_cv.observe(y, X)
+            optuna_search_cv.observe(y, X_actual=X)
 
     def test_observe_predict_before_fit_raises_error(self, optuna_search_cv, y_X_factory):
         """Test that observe_predict() before fit raises AttributeError."""
         y, X = y_X_factory(length=10, n_targets=1, n_features=2)
         with pytest.raises(AttributeError):
-            optuna_search_cv.observe_predict(y, X, forecasting_horizon=3)
+            optuna_search_cv.observe_predict(y, X_actual=X, forecasting_horizon=3)
 
 
 @pytest.mark.slow
@@ -1556,7 +1568,7 @@ class TestStress:
             n_trials=10,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert len(search.cv_results_["params"]) == 10
         for key in ["param_estimator__alpha", "param_estimator__fit_intercept"]:
             assert key in search.cv_results_
@@ -1574,7 +1586,7 @@ class TestStress:
             n_trials=20,
             cv=2,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert len(search.cv_results_["params"]) == 20
 
 
@@ -1601,7 +1613,7 @@ class TestStorageIntegration:
             cv=2,
             storage=storage,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
 
         # Verify database file was created
         assert db_path.exists()
@@ -1630,7 +1642,7 @@ class TestStorageIntegration:
             cv=2,
             refit=False,
         )
-        search1.fit(y, X, forecasting_horizon=3, study=study1)
+        search1.fit(y, X_actual=X, forecasting_horizon=3, study=study1)
         first_count = len(study1.trials)
 
         # Resume with same study
@@ -1646,7 +1658,7 @@ class TestStorageIntegration:
             cv=2,
             refit=False,
         )
-        search2.fit(y, X, forecasting_horizon=3, study=study2)
+        search2.fit(y, X_actual=X, forecasting_horizon=3, study=study2)
 
         # Should have 4 total trials
         assert len(study2.trials) == first_count + 2
@@ -1658,7 +1670,7 @@ class TestIntervalPrediction:
     def test_point_forecaster_no_predict_interval(self, optuna_search_cv, y_X_factory):
         """Test that point forecaster does not have predict_interval available."""
         y, X = y_X_factory(length=100, n_targets=1, n_features=2)
-        optuna_search_cv.fit(y, X, forecasting_horizon=3)
+        optuna_search_cv.fit(y, X_actual=X, forecasting_horizon=3)
 
         # PointReductionForecaster doesn't support interval prediction
         # The method should not be available via available_if decorator
@@ -1683,7 +1695,7 @@ class TestIntervalPrediction:
             cv=2,
             refit=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_forecaster_")
 
     @pytest.mark.slow
@@ -1704,7 +1716,7 @@ class TestIntervalPrediction:
             cv=2,
             refit=True,
         )
-        search.fit(y, X, forecasting_horizon=3)
+        search.fit(y, X_actual=X, forecasting_horizon=3)
         assert hasattr(search, "best_forecaster_")
 
     def test_point_forecaster_with_interval_scorer_raises(self, y_X_factory, default_sampler):
@@ -1723,7 +1735,7 @@ class TestIntervalPrediction:
             cv=2,
         )
         with pytest.raises(ValueError, match="interval"):
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
 
 class TestClassProbaPrediction:
@@ -1856,7 +1868,7 @@ class TestClassProbaPrediction:
             cv=2,
         )
         with pytest.raises(ValueError, match="class"):
-            search.fit(y, X, forecasting_horizon=3)
+            search.fit(y, X_actual=X, forecasting_horizon=3)
 
     def test_class_proba_forecaster_with_point_scorer_raises(
         self, class_proba_forecaster, y_class_proba_factory, default_sampler

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -39,7 +39,7 @@ class TestOptunaSearchCVSystematicChecks:
 
         train_len = 80
         y_train, y_test = y[:train_len], y[train_len:]
-        X_train, X_test = X[:train_len], X[train_len:]
+        X_actual_train, X_actual_test = X[:train_len], X[train_len:]
 
         search_cv = OptunaSearchCV(
             forecaster=PointReductionForecaster(estimator=Ridge()),
@@ -54,7 +54,7 @@ class TestOptunaSearchCVSystematicChecks:
         )
 
         search_cv_fitted = clone(search_cv)
-        search_cv_fitted.fit(y_train, X_actual=X_train, forecasting_horizon=3)
+        search_cv_fitted.fit(y_train, X_actual=X_actual_train, forecasting_horizon=3)
 
         tags = {
             "search_type": "optuna",
@@ -65,7 +65,7 @@ class TestOptunaSearchCVSystematicChecks:
 
         run_checks(
             search_cv_fitted,
-            _yield_yohou_search_checks(search_cv_fitted, y_train, X_train, y_test, X_test, tags=tags),
+            _yield_yohou_search_checks(search_cv_fitted, y_train, X_actual_train, y_test, X_actual_test, tags=tags),
             expected_failures=self.EXPECTED_FAILURES,
         )
 
@@ -1332,6 +1332,32 @@ class TestIntegration:
         )
         search.fit(y, X_actual=X, forecasting_horizon=3)
         y_pred = search.predict(forecasting_horizon=3)
+        assert y_pred is not None
+        assert len(y_pred) > 0
+
+    @pytest.mark.filterwarnings("ignore::sklearn.exceptions.DataConversionWarning")
+    def test_fit_with_x_future(self, y_X_factory, default_sampler):
+        """Test OptunaSearchCV passes X_future through fit and predict."""
+        import polars as pl
+        from sklearn.ensemble import HistGradientBoostingRegressor
+
+        y, X = y_X_factory(length=100, n_targets=1, n_features=2)
+        time_col = y["time"]
+        X_future = pl.DataFrame({"time": time_col, "future_feat": range(len(time_col))})
+
+        search = OptunaSearchCV(
+            forecaster=PointReductionForecaster(estimator=HistGradientBoostingRegressor(max_iter=10)),
+            param_distributions={
+                "estimator__max_iter": CategoricalDistribution([10, 20]),
+            },
+            scoring=MeanAbsoluteError(),
+            sampler=default_sampler,
+            n_trials=2,
+            cv=2,
+        )
+        search.fit(y, X_actual=X, forecasting_horizon=1, X_future=X_future)
+        assert hasattr(search, "best_params_")
+        y_pred = search.predict(forecasting_horizon=1)
         assert y_pred is not None
         assert len(y_pred) > 0
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1807,7 +1807,8 @@ class TestClassProbaPrediction:
 
     def test_class_proba_multimetric(self, class_proba_forecaster, y_class_proba_factory, default_sampler):
         """Test multi-metric scoring with class proba scorers."""
-        from yohou.metrics.class_proba import Accuracy, BrierScore
+        from yohou.metrics.class_proba import BrierScore
+        from yohou.metrics.classification import Accuracy
 
         y = y_class_proba_factory(length=100)
         scoring = {


### PR DESCRIPTION
## Description

Rename the exogenous parameter from `X` to `X_actual` across the public API. Add `X_future` and `X_forecast` forwarding in `OptunaSearchCV` objective and search classes. Update skills and tests for the new API.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Other (please describe):

## Motivation and Context

Align with the new yohou core exogenous features API (`X_actual`, `X_future`, `X_forecast`).

## Checklist

- [x] My code follows the code style of this project
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed
- [x] My changes generate no new warnings

## Additional Notes

Companion PR to stateful-y/yohou#56.