### PR TITLE
chore(template): update from python-package-copier v0.28.4

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: c3f6fcf8b6f2ce00e96ae5b918cff755cda0a545
+_commit: d6d0e8260d71339ffe46610d42b2ee4e5061ca93
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Please review our [Code of Conduct](CODE_OF_CONDUCT.md) before participating.
 git clone <repo-url>
 cd <project-dir>
 uv sync --group dev
-uv run prek install
+uv run prek install -f
 just test-fast
 ```
 

--- a/docs/pages/how-to/contribute.md
+++ b/docs/pages/how-to/contribute.md
@@ -35,7 +35,7 @@ uv sync --group dev
 4. Install the git hooks (required):
 
 ```bash
-uv run prek install
+uv run prek install -f
 ```
 
 ## Development Workflow

--- a/justfile
+++ b/justfile
@@ -7,7 +7,11 @@ default:
 # Install dependencies and git hooks
 install:
     uv sync --group dev
-    uv run prek install
+    # -f matters: without it prek finds a pre-v0.27.0 shim, moves it to
+    # `.git/hooks/pre-commit.legacy` and CHAINS it -- both hooks then run on
+    # every commit. `-f` overwrites instead. Measured; the migration notice
+    # prek prints names this flag, and this is the command people actually run.
+    uv run prek install -f
 
 # Run tests and doctests with parallel execution
 test:


### PR DESCRIPTION
Updates from python-package-copier **v0.28.3** → **v0.28.4** (`d6d0e826`).

Changes `uv run prek install` to `uv run prek install -f` in three places, plus a 4-line explanatory comment in the justfile.

**Why:** without `-f`, prek finds a pre-v0.27.0 shim, moves it to `.git/hooks/pre-commit.legacy` and **chains** it — both hooks then run on every commit. `-f` overwrites instead. Since `just install` is the command people already run, the routine path becomes self-healing.

Verified independently that the flag is real and means what the comment says — `prek install --help` documents `-f, --overwrite  Overwrite existing Git shims`. Worth checking, since a bad flag here would break `just install` fleet-wide.

## Scope: docs and tooling only

| file | change |
|---|---|
| `justfile` | `-f` + 4-line comment |
| `CONTRIBUTING.md` | `-f` |
| `docs/pages/how-to/contribute.md` | `-f` |

Each whole-file diff is the template change **and nothing else**. No code, no config, no `_api_pages.py` — `docs/_api_pages.py` (`d4621a4c…`) and `docs/hooks.py` (`ed97544c…`) are byte-unchanged from v0.28.3.

## Local content preserved

`docs/pages/how-to/contribute.md` **had local drift** into the template's version — prose edits at lines 288–289 and 364–370 that diverge from the pristine render. That is the shape that has silently destroyed curated content in this fleet before, since the `-f` hunk lands in the same file.

It applied cleanly and the drift survived intact: the file's whole-file diff is the single `-f` line, the line count is unchanged at 727, and all three drifted passages are still present verbatim. `justfile` and `CONTRIBUTING.md` byte-matched pristine beforehand, so they carried no risk.

## Verification

- **`git status --porcelain`: no `U` states**, and `git diff --name-only --diff-filter=U` empty. **No `.rej` and no `.orig`** anywhere in the worktree. (The single `.orig` on disk is inside `.nox/`, a jupyterlab package artifact, out of scope.)
- **`git diff --stat -- docs/assets`: empty** — verbatim, no output. All 7 asset hashes byte-identical.
- **Symbol set 4 → 4**, re-confirmed rather than re-derived: symbol dict and name-lookup dict both compare equal to the v0.28.3 capture.
- **`nox -s check_docs`: exit 0, 0 warnings, 0 `api:` diagnostics.** The `^api:` grep is falsified against a positive control that emits 7.
- **Rendered site: 111 → 111 files**, and after normalising the git SHA in the `View on GitHub` permalinks the diff is exactly 3 artifacts, all downstream of the one changed page: `pages/how-to/contribute/index.html`, its copied `.md`, and `search/search_index.json` (same document set, text-only delta). The rendered HTML delta is a **single line** — `prek install` → `prek install -f`. The SHA normaliser is falsified live (7 rewrites).
- **`.claude/skills/`: 36 files across 15 skills** still tracked and byte-identical. Tracked inventory unchanged at 119 files.
- **`mkdocs.yml` untouched**; nav remains 17 leaves.
