### PR TITLE
fix(ci): pin exact uv version in setup-uv steps

### DIFF
--- a/.claude/skills/update-from-template/SKILL.md
+++ b/.claude/skills/update-from-template/SKILL.md
@@ -179,6 +179,26 @@ without it. Anyone who skips this keeps invoking a runner that can no longer par
 they get a confusing failure rather than a clean one. Tell every contributor, not just
 whoever ran the update.
 
+### Pin uv in workflows the template does not own
+
+`copier update` only touches files the template generates. The templated workflows
+(`tests.yml`, `changelog.yml`, `nightly.yml`, `commit-message.yml`) pin an exact uv
+version on every `astral-sh/setup-uv` step:
+
+```yaml
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"   # exact X.Y.Z, not "latest" or a range
+          # ...existing enable-cache / cache-dependency-glob stay as they are
+```
+
+An unpinned step resolves "latest" over the network on every run, and a transient
+blip there fails the job in a fraction of a second with `##[error]fetch failed`,
+before any real work. **Any workflow you added yourself** (anything not in the list
+above) keeps its own `astral-sh/setup-uv` steps, and the update leaves them untouched.
+After syncing, add the same exact `version:` pin to those steps by hand, matching the
+value the templated workflows now use, so the flake cannot reach your bespoke CI either.
+
 ```bash
 git add -A
 git commit -m "chore: update from template <version>"

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,7 +1,7 @@
 # This file is used by Copier to track the template version
 # and enable template updates in generated projects
 
-_commit: a327e3f6ffbbfd9c938e70dcd44d72dcdaf9272e
+_commit: dbde7ae7632a1bb5a2018c882863ce35fcbd4a39
 _src_path: gh:stateful-y/python-package-copier
 author_email: gtauzin@stateful-y.io
 author_name: Guillaume Tauzin
@@ -15,3 +15,4 @@ min_python_version: '3.11'
 package_name: yohou_optuna
 project_name: Yohou-Optuna
 project_slug: yohou-optuna
+uv_version: '0.10.0'

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -46,6 +46,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"
 
       - name: Run hooks on generated CHANGELOG
         run: |
@@ -100,6 +102,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/commit-message.yml
+++ b/.github/workflows/commit-message.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          version: "0.10.0"
 
       - name: Set up Python
         run: uv python install

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -71,6 +72,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -106,6 +108,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -151,6 +154,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -178,6 +182,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -204,6 +209,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 
@@ -257,6 +263,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
+          version: "0.10.0"
           enable-cache: true
           cache-dependency-glob: "pyproject.toml"
 


### PR DESCRIPTION
Applies template release **v0.29.6** (from v0.29.5) to this repo.

## What changed
- **Pins `version: "0.10.0"`** as the first `with:` key of every `astral-sh/setup-uv` step across the CI workflows: `tests.yml` (7 steps), `changelog.yml` (2), `commit-message.yml` (1), `nightly.yml` (1) — **11 setup-uv steps total, 0 left unpinned**.
- Records **`uv_version: '0.10.0'`** in `.copier-answers.yml` (and bumps `_commit` a327e3f -> dbde7ae).
- Adds a ~20-line section to `.claude/skills/update-from-template/SKILL.md` (template-owned skill; 20 insertions, 0 deletions).

## Bespoke-workflow audit
Content-walked all `.github/workflows/*.yml`. No bespoke/unpinned setup-uv steps remain; **no hand-pinning needed** — every pin came from copier. `pr-title.yml` and `publish-release.yml` use no setup-uv.

## Scope check
No conflicts / no `.rej` files. Diff is exactly 6 files. `docs/assets`, `mkdocs.yml`, `src/`, and binaries untouched. The 15 custom skills (36 files) under `.claude/skills/` are unchanged except the one template-owned SKILL.md.

**Held for review — do NOT merge.**
